### PR TITLE
feat: Textual TUI visual overhaul with async game loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ store.pckl
 
 # Docs/specs (local only)
 docs/superpowers/
+.superpowers/
 
 # npm
 .npmrc

--- a/docs/plans/2026-03-28-001-feat-tui-visual-overhaul-plan.md
+++ b/docs/plans/2026-03-28-001-feat-tui-visual-overhaul-plan.md
@@ -1,0 +1,458 @@
+---
+title: "feat: Comprehensive TUI Visual Overhaul"
+type: feat
+status: completed
+date: 2026-03-28
+---
+
+# Comprehensive TUI Visual Overhaul
+
+## Overview
+
+Overhaul the Emberblast Textual TUI from a functional prototype into a polished, game-friendly RPG interface. The current layout is functional but visually sparse — the map is too small, the character info is incomplete, and the overall feel doesn't match a tactical RPG. This plan restructures the layout, makes the map the visual centerpiece, adds a persistent character badge, and polishes every widget for a cohesive game experience.
+
+## Problem Frame
+
+The current TUI works but doesn't feel like a game:
+- Map is small and crammed into one corner with tiny cells
+- Character stats panel only shows when it's your turn (should be persistent)
+- No enemy detail panel — enemies are a compact list inside the HUD
+- Combat log works but has no visual personality
+- Action bar is plain text, not the colorful button layout from the design mockup
+- No visual feedback during combat (damage numbers, status effects)
+- Overall layout proportions waste screen space
+
+## Requirements Trace
+
+- R1. Map must be the visual centerpiece — take maximum available width, with larger cells and clear terrain distinction
+- R2. A fixed "character badge" panel must always be visible showing the controlled player's full stats, equipment, and status effects
+- R3. Enemy info must be a separate dedicated panel (not crammed into the player HUD)
+- R4. Combat log must auto-scroll, be visually structured, and feel like an RPG battle log
+- R5. Action bar must show colored keybinding buttons matching the design mockup
+- R6. Layout must use Textual's grid system for proper proportional sizing
+- R7. All widgets must have consistent visual style (borders, colors, spacing)
+- R8. Movement selection must clearly highlight reachable cells and flash the currently selected cell
+
+## Scope Boundaries
+
+- No gameplay logic changes — only rendering and UI layout
+- No new Textual dependencies beyond what's already installed
+- No changes to the questioner/event/renderer architecture — only what widgets render
+- No responsive breakpoints — optimize for standard terminal size (80x24 minimum, 120x40+ ideal)
+- Title screen, setup screens, and game over screen are out of scope
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `emberblast/tui/screens/battle.py` — Current layout uses `Horizontal`/`Vertical` containers
+- `emberblast/tui/widgets/map_grid.py` — Map renders via `_build_grid_text()` returning Rich `Text`
+- `emberblast/tui/widgets/player_hud.py` — Combined player + enemy info widget
+- `emberblast/tui/widgets/combat_log.py` — RichLog-based scrollable log
+- `emberblast/tui/widgets/action_bar.py` — Docked bottom bar with keybinding display
+- `emberblast/tui/app.py` — Bridge methods for widget updates
+- `emberblast/tui/renderer.py` — Event dispatch with `_refresh_game_state()`
+- `emberblast/tui/styles.py` — Shared color constants
+
+### Textual Capabilities (v8.2.0)
+
+- **Grid layout** (`layout: grid`) with `grid-size`, `grid-columns`, `grid-rows`, `column-span`, `row-span` for complex multi-panel layouts
+- **ScrollView** with `render_line()` line API for high-performance per-row rendering (ideal for large maps)
+- **Reactive properties** (`reactive()`) for automatic widget refresh on state changes
+- **VerticalScroll** container for scrollable panels
+- **Dock** for fixed header/footer
+- **Grid gutter** — `grid-gutter: 1 2` for visually even spacing (terminal cells are ~2x taller than wide)
+- **RichLog** for combat log (already in use)
+
+## Key Technical Decisions
+
+- **Switch from Horizontal/Vertical to Grid layout**: The current nested container approach makes proportional sizing brittle. Grid gives direct control over column/row sizing and spanning. Rationale: Grid is the standard Textual approach for multi-panel layouts.
+
+- **Split PlayerHUDWidget into two widgets — CharacterBadge + EnemyPanel**: The current widget tries to do too much. Separate widgets have independent sizing, borders, and update cycles. The character badge stays compact and always visible; the enemy panel can scroll when there are many enemies.
+
+- **Use reactive properties for widget state**: Currently all widgets use manual `self.refresh()` calls. Reactive properties batch updates automatically and make the code cleaner.
+
+- **Map uses wider cells (5 chars) with double-height rows**: Each map cell becomes ` ░░░ ` (5 chars wide) and rows get a blank line between them for visual breathing room. This makes terrain patterns and player tokens much more readable at a glance.
+
+- **Action bar uses a proper button layout**: Instead of "[M] Move  [A] Attack" as plain text, each action gets a bordered box with colored text, matching the design mockup.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should the map use ScrollView with line API?** No — the grid is typically 8x8 which fits in any terminal. The Rich Text approach is simpler and sufficient. ScrollView is only needed for maps larger than the visible area.
+- **Should we add animations/timers?** Not in this plan. Focus on static visual quality first. Animation (damage numbers floating, turn transitions) can be a follow-up.
+
+### Deferred to Implementation
+
+- Exact CSS pixel values for grid proportions — will need tuning in a real terminal
+- Whether `grid-gutter` looks better than explicit border spacing — try both
+
+## Implementation Units
+
+- [ ] **Unit 1: Grid Layout Restructure**
+
+  **Goal:** Replace the Horizontal/Vertical container layout with a proper CSS Grid that gives each panel dedicated space.
+
+  **Requirements:** R1, R6, R7
+
+  **Dependencies:** None
+
+  **Files:**
+  - Modify: `emberblast/tui/screens/battle.py`
+  - Test: `emberblast/test/test_battle_screen.py` (if exists, otherwise structural tests via existing test suite)
+
+  **Approach:**
+  The new BattleScreen layout uses a 2-column, 3-row grid:
+  ```
+  ┌──────────────────────────────────┬───────────────────┐
+  │         Turn Header (span 2)     │                   │
+  ├──────────────────────────────────┼───────────────────┤
+  │                                  │  Character Badge  │
+  │           MAP (large)            ├───────────────────┤
+  │                                  │   Enemy Panel     │
+  ├──────────────────────────────────┼───────────────────┤
+  │        Action Bar (span 2)       │                   │
+  └──────────────────────────────────┴───────────────────┘
+  │            Combat Log (span 2)   │
+  └──────────────────────────────────┘
+  ```
+
+  Actually, simpler — keep docked header/footer, use grid for the middle:
+  - TurnHeader: docked top
+  - ActionBar: docked bottom
+  - Middle area: 2-column grid
+    - Left (3fr): MapWidget (full height)
+    - Right (2fr): Vertical with CharacterBadge (fixed height) + EnemyPanel (auto) + CombatLog (1fr)
+
+  Use `Horizontal` with fr units (which already works) but fix the proportions and add proper IDs for CSS targeting. The key change is giving the map MORE space (use `width: 3fr` for map, `width: 1fr` for right panel) and removing wasted space.
+
+  **Patterns to follow:**
+  - Existing `BattleScreen.compose()` pattern
+  - Textual's docking for header/footer
+
+  **Test scenarios:**
+  - Happy path: BattleScreen composes all expected widgets (turn-header, map-widget, character-badge, enemy-panel, combat-log, action-bar) — verify via `query_one` for each ID
+  - Happy path: Widget hierarchy is correct — map is in left column, info panels in right column
+
+  **Verification:**
+  - Running the app shows a proportional layout with map taking ~60% width and info panels taking ~40%
+
+- [ ] **Unit 2: Character Badge Widget**
+
+  **Goal:** Create a dedicated, always-visible character info panel showing the controlled player's full stats with visual polish.
+
+  **Requirements:** R2, R7
+
+  **Dependencies:** Unit 1 (layout must have a slot for it)
+
+  **Files:**
+  - Create: `emberblast/tui/widgets/character_badge.py`
+  - Modify: `emberblast/tui/screens/battle.py` (add to compose)
+  - Modify: `emberblast/tui/app.py` (add bridge method)
+  - Modify: `emberblast/tui/renderer.py` (update `_refresh_game_state`)
+  - Test: `emberblast/test/test_character_badge.py`
+
+  **Approach:**
+  A new `CharacterBadgeWidget(Widget)` that renders:
+  - Sword emoji + player name (bold, blue) + race
+  - Job name + "Lv.X" (orange)
+  - HP bar: colored block bar (20 chars) with numeric values
+  - MP bar: colored block bar (20 chars) with numeric values
+  - Full stats: STR, INT, ACC, ARM, RES, SPD, WILL in a compact grid
+  - Position indicator: current grid position (e.g., "Pos: D5")
+  - Active status effects (if any)
+
+  Uses reactive properties: `_player = reactive(None)` triggers auto-refresh on update.
+
+  Styled with green border (matching "friendly" color) and dark panel background.
+
+  **Patterns to follow:**
+  - Current `PlayerHUDWidget._build_hud_text()` for bar rendering
+  - `_build_bar()` helper function (move to shared utils or keep in widget)
+
+  **Test scenarios:**
+  - Happy path: Widget renders player name, job, race, level when player data is set
+  - Happy path: HP and MP bars render with correct fill ratio
+  - Happy path: Stats line shows all 7 attributes
+  - Edge case: Widget shows "No player data" when player is None
+  - Edge case: HP at 0 renders full red bar with 0/max
+
+  **Verification:**
+  - Character badge always visible during battle, showing current player stats
+  - Stats update after taking damage, leveling up, using mana
+
+- [ ] **Unit 3: Enemy Panel Widget**
+
+  **Goal:** Create a dedicated scrollable panel showing all enemy information with individual HP bars and status.
+
+  **Requirements:** R3, R7
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Create: `emberblast/tui/widgets/enemy_panel.py`
+  - Modify: `emberblast/tui/screens/battle.py` (add to compose)
+  - Modify: `emberblast/tui/app.py` (add bridge method)
+  - Modify: `emberblast/tui/renderer.py` (update `_refresh_game_state`)
+  - Test: `emberblast/test/test_enemy_panel.py`
+
+  **Approach:**
+  A new `EnemyPanelWidget(Widget)` that renders each alive enemy as a mini-card:
+  - "ENEMIES" header with red styling
+  - Per enemy: skull emoji + name (red) + job + "Lv.X"
+  - Mini HP bar (12 chars) with numeric values
+  - Position indicator
+  - Dead enemies shown as struck-through or greyed out
+
+  Styled with red border (matching "enemy" color).
+
+  The enemy list is passed separately from the character badge — they have independent update cycles.
+
+  **Patterns to follow:**
+  - Current enemy list rendering in `PlayerHUDWidget._build_hud_text()`
+
+  **Test scenarios:**
+  - Happy path: Panel renders all alive enemies with name, job, HP bar
+  - Happy path: Dead enemies are visually distinct (greyed out)
+  - Edge case: Empty enemy list shows "No enemies" placeholder
+  - Edge case: Single enemy renders correctly without list artifacts
+
+  **Verification:**
+  - Enemy panel updates each turn showing current enemy HP
+  - Dead enemies visually change appearance
+
+- [ ] **Unit 4: Enhanced Map Widget**
+
+  **Goal:** Make the map the visual centerpiece with larger cells, better terrain distinction, and clear player identification.
+
+  **Requirements:** R1, R8
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Modify: `emberblast/tui/widgets/map_grid.py`
+  - Modify: `emberblast/tui/styles.py` (terrain style constants)
+  - Test: `emberblast/test/test_map_widget.py`
+
+  **Approach:**
+  Increase cell width to 5 characters and add vertical spacing between rows:
+  - Each cell: ` ░░░ ` (5 chars) — more visual weight for terrain
+  - Row spacing: blank half-row between grid rows for readability
+  - Player tokens: 3 chars centered (` GK `) instead of 2
+  - Terrain backgrounds: deeper, more saturated colors
+  - Grid border: thicker box-drawing characters (`║`, `═`, `╔`, `╗`, `╚`, `╝`)
+  - Column headers: spaced to match new cell width
+  - Movement highlights: bright pulsing cyan with `▸` markers on highlighted cells
+  - Flash cell (selected): inverted bright white background
+  - Legend at bottom: larger token previews with full name
+
+  New terrain symbols with more visual texture:
+  - Plains: `·.·` (sparse dots)
+  - Wall: `███` (solid)
+  - Water: `≈≈≈` (water waves)
+  - Mountain: `⌂△⌂` (peaks)
+  - Forest: `♠♣♠` (trees)
+
+  **Patterns to follow:**
+  - Current `_build_grid_text()` structure
+  - `_TERRAIN_STYLE` dict pattern
+
+  **Test scenarios:**
+  - Happy path: Grid renders with column headers and row labels at new cell width
+  - Happy path: Player tokens appear at correct positions
+  - Happy path: Terrain types render with distinct symbols and colors
+  - Happy path: Highlight cells render with cyan styling
+  - Happy path: Flash cells render with inverted styling
+  - Edge case: Void cells (value 0) render as blank space at correct width
+  - Edge case: Dead players are excluded from rendering
+
+  **Verification:**
+  - Map visually dominates the left side of the screen
+  - Different terrain types are immediately distinguishable
+  - Player tokens are clearly visible with team coloring
+  - Movement highlights clearly show reachable cells
+
+- [ ] **Unit 5: Polished Action Bar**
+
+  **Goal:** Transform the action bar from plain text into styled, bordered action buttons matching the design mockup.
+
+  **Requirements:** R5, R7
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Modify: `emberblast/tui/widgets/action_bar.py`
+  - Test: `emberblast/test/test_action_bar.py` (if exists)
+
+  **Approach:**
+  Each action renders as a "button" using box-drawing characters:
+  ```
+  ┌───────┐  ┌─────────┐  ┌───────┐  ┌─────────┐  ┌───────┐
+  │[M]ove │  │[A]ttack │  │[S]kill│  │[D]efend │  │[I]tem │
+  └───────┘  └─────────┘  └───────┘  └─────────┘  └───────┘
+  ```
+  Each button's border color matches its action color from `ACTION_COLORS`. The key letter is bold and highlighted.
+
+  When in "choices" mode, the status line appears above the buttons (or replaces them if actions aren't relevant).
+
+  Increase action bar height from 3 to 4 to accommodate the bordered buttons.
+
+  **Patterns to follow:**
+  - Current `_build_bar_text()` approach
+  - `ACTION_COLORS` and `ACTION_KEYS` mappings
+
+  **Test scenarios:**
+  - Happy path: Actions render with bordered button format
+  - Happy path: Each button uses its action color
+  - Happy path: Status message displays when set
+  - Edge case: Empty action list renders no buttons
+
+  **Verification:**
+  - Action bar shows colored bordered buttons during action selection
+  - Visual style matches the design mockup
+
+- [ ] **Unit 6: Combat Log Polish**
+
+  **Goal:** Improve combat log visual structure with better formatting, icons, and category-specific styling.
+
+  **Requirements:** R4, R7
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Modify: `emberblast/tui/widgets/combat_log.py`
+  - Modify: `emberblast/tui/styles.py` (add log category icons)
+  - Test: `emberblast/test/test_combat_log_widget.py`
+
+  **Approach:**
+  Add category-specific icons/prefixes to log entries:
+  - Damage: `⚔` sword icon, red
+  - Heal: `✚` cross icon, green
+  - Move: `→` arrow, blue
+  - Skill: `✦` star, purple
+  - Death: `☠` skull, bold red
+  - Victory: `🏆` trophy, bold green
+  - Narration: `"` quote marks, orange italic
+  - Item: `◆` diamond, green
+  - Level up: `⬆` arrow up, bold green
+  - XP: `★` star, yellow
+  - Turn start: larger separator with turn number centered
+
+  Turn headers get a distinct visual treatment:
+  ```
+  ═══════════ TURN 3 ═══════════
+  ```
+
+  The "COMBAT LOG" header gets a proper styled banner.
+
+  **Patterns to follow:**
+  - Current `add_entry()` and `on_mount()` pattern
+  - `LOG_COLORS` mapping
+
+  **Test scenarios:**
+  - Happy path: Widget is instance of RichLog with auto_scroll enabled
+  - Happy path: Turn number tracking works via set_turn()
+  - Happy path: add_entry and clear_log methods exist and are callable
+
+  **Verification:**
+  - Log entries have distinctive icons per category
+  - Turn transitions are visually clear separators
+  - Log auto-scrolls to newest entries
+
+- [ ] **Unit 7: Wire Everything Together**
+
+  **Goal:** Update the app bridge methods, renderer, and entry point to work with the new widget structure.
+
+  **Requirements:** R2, R3 (persistent updates)
+
+  **Dependencies:** Units 1-6
+
+  **Files:**
+  - Modify: `emberblast/tui/app.py` (new bridge methods for character badge and enemy panel)
+  - Modify: `emberblast/tui/renderer.py` (update `_refresh_game_state` to update new widgets)
+  - Modify: `emberblast/__main__.py` (initial data population for new widgets)
+  - Modify: `emberblast/tui/screens/battle.py` (remove old PlayerHUDWidget references)
+  - Delete: `emberblast/tui/widgets/player_hud.py` (replaced by character_badge + enemy_panel)
+  - Test: `emberblast/test/test_tui_app.py` (update structural tests)
+
+  **Approach:**
+  - Replace `update_hud(player)` + `update_enemies(enemies)` with `update_character_badge(player)` + `update_enemy_panel(enemies)`
+  - `_refresh_game_state` always finds the controlled player and updates the badge; finds all enemies and updates the enemy panel
+  - Initial data population in `__main__.py` uses new bridge methods
+  - Remove `PlayerHUDWidget` references everywhere
+  - Clean up old test files for removed widget
+
+  **Patterns to follow:**
+  - Current bridge method pattern in `app.py`
+  - `_refresh_game_state` pattern in `renderer.py`
+
+  **Test scenarios:**
+  - Happy path: App has `update_character_badge` and `update_enemy_panel` methods
+  - Happy path: BattleScreen composes character-badge and enemy-panel widgets
+  - Integration: Renderer `_refresh_game_state` calls badge and panel updates
+
+  **Verification:**
+  - Game launches, transitions to battle screen, all panels populated
+  - Character badge persists across all turns (doesn't blank out during bot turns)
+  - Enemy panel updates after each action (damage, death, movement)
+  - Combat log scrolls and shows all events
+  - Map highlights work during movement selection
+
+- [ ] **Unit 8: Visual Consistency Pass**
+
+  **Goal:** Final polish pass ensuring consistent borders, colors, spacing, and visual hierarchy across all widgets.
+
+  **Requirements:** R7
+
+  **Dependencies:** Units 1-7
+
+  **Files:**
+  - Modify: `emberblast/tui/styles.py` (finalize color palette)
+  - Modify: Various widget CSS as needed
+  - Modify: `emberblast/tui/screens/battle.py` (final CSS tuning)
+
+  **Approach:**
+  - Ensure all panels use consistent border styles (solid borders with appropriate team/category colors)
+  - Turn header: orange border
+  - Character badge: green border (friendly)
+  - Enemy panel: red border (enemy)
+  - Combat log: grey border (neutral)
+  - Action bar: grey top border
+  - Map: orange border
+  - Verify spacing between panels is even
+  - Ensure dark theme consistency — all backgrounds use `#0d1117` or `#161b22`
+  - Test at different terminal sizes to verify proportions
+
+  **Test scenarios:**
+  - Happy path: All widgets have non-empty DEFAULT_CSS with border and background
+  - Happy path: Color constants in styles.py are consistent across widget usage
+
+  **Verification:**
+  - Screenshots of the running game show a cohesive, polished visual style
+  - No visual artifacts, overlapping borders, or misaligned panels
+  - Layout looks good at both 80-column and 120-column terminal widths
+
+## System-Wide Impact
+
+- **Widget query changes:** `app.py` bridge methods change from `#player-hud` to `#character-badge` and `#enemy-panel` — all query_one calls must be updated
+- **Renderer coupling:** `_refresh_game_state()` must update two new widgets instead of one — the controlled player goes to badge, enemies go to panel
+- **Test impact:** Tests referencing `PlayerHUDWidget` must be updated or removed
+- **CSS specificity:** New grid layout CSS must not conflict with widget DEFAULT_CSS
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Grid layout doesn't render well at small terminal sizes | Set reasonable `min-width`/`min-height` on widgets; test at 80x24 |
+| Widget query_one fails during screen transitions | Keep existing try/except pattern with logging |
+| RichLog performance with many entries | Already using `max_lines` cap — monitor |
+| Box-drawing characters don't render in all terminals | Use Unicode block elements that have broad support |
+
+## Sources & References
+
+- Textual Layout Guide: https://textual.textualize.io/how-to/design-a-layout/
+- Textual Grid Styles: https://textual.textualize.io/styles/grid/
+- Textual Reactivity: https://textual.textualize.io/guide/reactivity/
+- Textual RichLog: https://textual.textualize.io/widgets/rich_log/
+- Textual Containers: https://textual.textualize.io/api/containers/

--- a/emberblast/__main__.py
+++ b/emberblast/__main__.py
@@ -1,3 +1,4 @@
+import asyncio
 import atexit
 import os
 
@@ -15,28 +16,29 @@ def exit_handler(orchestrator):
 
 @communicator_injector()
 class Emberblast(IEmberblast):
-    def run(self):
+    async def run(self):
         try:
             if not os.environ.get("OPENAI_API_KEY"):
                 print("Warning: OPENAI_API_KEY not set. Bots will use deterministic AI.")
             self.communicator.informer.render(GreetingsEvent())
             game_factory = GameFactory()
-            game_orchestrator = game_factory.pre_initial_settings()
+            game_orchestrator = await game_factory.pre_initial_settings()
             atexit.register(exit_handler, game_orchestrator)
-            game_orchestrator.execute_game()
+            await game_orchestrator.execute_game()
         except KeyboardInterrupt:
             pass
         except Exception as err:
             print(err)
             print("System shutdown with unexpected error")
 
-    __call__ = run
+    def __call__(self):
+        asyncio.run(self.run())
 
 
 if __name__ == "__main__":
-    Emberblast().run()
+    asyncio.run(Emberblast().run())
 
 
 # pip cmd initializer
 def run_project():
-    Emberblast().run()
+    asyncio.run(Emberblast().run())

--- a/emberblast/__main__.py
+++ b/emberblast/__main__.py
@@ -68,6 +68,9 @@ def run_textual():
             # Store orchestrator ref so renderer can pull map/player data
             app._orchestrator = game_orchestrator
 
+            # Wait for the BattleScreen to mount before rendering initial data
+            await asyncio.sleep(0.3)
+
             # Render initial map
             from emberblast.events import MapInfoEvent
 
@@ -83,6 +86,8 @@ def run_textual():
                         size=game_orchestrator.game.game_map.size,
                     )
                 )
+                # Also update HUD with first player
+                app.update_hud(first_player)
 
             await game_orchestrator.execute_game()
         except Exception as err:

--- a/emberblast/__main__.py
+++ b/emberblast/__main__.py
@@ -71,7 +71,11 @@ def run_textual():
             # Wait for the BattleScreen to mount before rendering initial data
             await asyncio.sleep(0.3)
 
-            # Render initial map
+            # Set the map name in the turn header
+            map_name = game_orchestrator.game.game_map.name if hasattr(game_orchestrator.game.game_map, "name") else ""
+            app.set_map_name(map_name)
+
+            # Render initial map and HUD
             from emberblast.events import MapInfoEvent
 
             all_players = game_orchestrator.game.get_all_players()
@@ -86,8 +90,14 @@ def run_textual():
                         size=game_orchestrator.game.game_map.size,
                     )
                 )
-                # Also update HUD with first player
-                app.update_hud(first_player)
+
+            # Update HUD with controlled player (not just first player)
+            for p in all_players:
+                if isinstance(p, IControlledPlayer):
+                    app.update_hud(p)
+                    non_controlled = [e for e in all_players if e != p and hasattr(e, "is_alive") and e.is_alive()]
+                    app.update_enemies(non_controlled)
+                    break
 
             await game_orchestrator.execute_game()
         except Exception as err:

--- a/emberblast/__main__.py
+++ b/emberblast/__main__.py
@@ -1,6 +1,7 @@
 import asyncio
 import atexit
 import os
+import sys
 
 from emberblast.communicator import communicator_injector
 from emberblast.events import GreetingsEvent
@@ -35,10 +36,53 @@ class Emberblast(IEmberblast):
         asyncio.run(self.run())
 
 
+def run_textual():
+    """Run the game with the Textual TUI."""
+    import emberblast.communicator.communicator as comm_mod
+    from emberblast.communicator import create_textual_communicator
+    from emberblast.interface import IControlledPlayer
+    from emberblast.tui.app import EmberblastApp
+
+    app = EmberblastApp()
+    textual_comm = create_textual_communicator(app)
+
+    # Override the global communicator singleton so all @communicator_injector classes use it
+    comm_mod.communicator = textual_comm
+
+    async def game_task():
+        try:
+            if not os.environ.get("OPENAI_API_KEY"):
+                app.post_combat_log("Warning: OPENAI_API_KEY not set. Bots will use deterministic AI.", "system")
+            game_factory = GameFactory()
+            game_factory.communicator = textual_comm
+            game_orchestrator = await game_factory.pre_initial_settings()
+
+            controlled_names = {
+                p.name for p in game_orchestrator.game.get_all_players() if isinstance(p, IControlledPlayer)
+            }
+            app.switch_to_battle(controlled_names)
+
+            game_orchestrator.communicator = textual_comm
+            game_orchestrator.bot_controller.communicator = textual_comm
+
+            await game_orchestrator.execute_game()
+        except Exception as err:
+            app.post_combat_log(f"Error: {err}", "damage")
+
+    app.set_game_task(game_task)
+    app.run()
+
+
 if __name__ == "__main__":
-    asyncio.run(Emberblast().run())
+    if "--classic" in sys.argv:
+        asyncio.run(Emberblast().run())
+    else:
+        run_textual()
 
 
 # pip cmd initializer
 def run_project():
-    asyncio.run(Emberblast().run())
+    if "--classic" in sys.argv:
+        asyncio.run(Emberblast().run())
+    else:
+        run_textual()

--- a/emberblast/__main__.py
+++ b/emberblast/__main__.py
@@ -65,6 +65,25 @@ def run_textual():
             game_orchestrator.communicator = textual_comm
             game_orchestrator.bot_controller.communicator = textual_comm
 
+            # Store orchestrator ref so renderer can pull map/player data
+            app._orchestrator = game_orchestrator
+
+            # Render initial map
+            from emberblast.events import MapInfoEvent
+
+            all_players = game_orchestrator.game.get_all_players()
+            first_player = all_players[0] if all_players else None
+            if first_player:
+                enemies = [p for p in all_players if p != first_player]
+                textual_comm.informer.render(
+                    MapInfoEvent(
+                        current_player=first_player,
+                        enemies=enemies,
+                        matrix=game_orchestrator.game.game_map.graph.matrix,
+                        size=game_orchestrator.game.game_map.size,
+                    )
+                )
+
             await game_orchestrator.execute_game()
         except Exception as err:
             app.post_combat_log(f"Error: {err}", "damage")

--- a/emberblast/bot/bot_decisioning.py
+++ b/emberblast/bot/bot_decisioning.py
@@ -1,3 +1,4 @@
+import asyncio
 import collections
 import functools
 import json
@@ -5,7 +6,6 @@ import logging
 import math
 import os
 import random
-import time
 from typing import Dict, List, Optional
 
 from emberblast.bot.llm_client import (
@@ -468,9 +468,9 @@ class BotDecisioning(IBotDecisioning):
         else:
             self.current_play_style = IPlayingMode.DEFENSIVE
 
-    def decide(self, player: IPlayer) -> None:
+    async def decide(self, player: IPlayer) -> None:
         if not self._llm_enabled:
-            self._decide_deterministic(player)
+            await self._decide_deterministic(player)
             return
 
         self.reset_attributes()
@@ -484,23 +484,23 @@ class BotDecisioning(IBotDecisioning):
         game_state = serialize_game_state(player, enemies, self.game, memory.get_entries(), available_actions)
         user_prompt = json.dumps(game_state, indent=2)
 
-        raw_response = call_openai(system_prompt, user_prompt)
+        raw_response = await asyncio.to_thread(call_openai, system_prompt, user_prompt)
         if raw_response is None:
             logger.warning("LLM call failed for %s, falling back to deterministic", player.name)
-            self._decide_deterministic(player)
+            await self._decide_deterministic(player)
             return
 
         parsed = parse_llm_response(raw_response)
         if parsed is None:
             logger.warning("Failed to parse LLM response for %s, falling back", player.name)
-            self._decide_deterministic(player)
+            await self._decide_deterministic(player)
             return
 
         success = self._execute_llm_action(player, parsed, enemies)
         if not success:
             # Retry once with error feedback
             error_msg = f"Previous action was invalid. Game state: {user_prompt}\nChoose a valid action."
-            raw_response = call_openai(system_prompt, error_msg)
+            raw_response = await asyncio.to_thread(call_openai, system_prompt, error_msg)
             if raw_response:
                 parsed = parse_llm_response(raw_response)
                 if parsed:
@@ -508,7 +508,7 @@ class BotDecisioning(IBotDecisioning):
 
             if not success:
                 logger.warning("LLM retry failed for %s, falling back to deterministic", player.name)
-                self._decide_deterministic(player)
+                await self._decide_deterministic(player)
                 return
 
         # Display narration if present
@@ -616,7 +616,7 @@ class BotDecisioning(IBotDecisioning):
                 return enemy
         return None
 
-    def _decide_deterministic(self, player: IPlayer) -> None:
+    async def _decide_deterministic(self, player: IPlayer) -> None:
         self.reset_attributes()
         self.current_bot = player
         self.sort_foes_by_priority()
@@ -626,22 +626,22 @@ class BotDecisioning(IBotDecisioning):
 
         if self.current_play_style == IPlayingMode.AGGRESSIVE and self.possible_foe is not None:
             self.attack()
-            time.sleep(1)
+            await asyncio.sleep(1)
             self.current_play_style = IPlayingMode.NEUTRAL
             self.move()
-            time.sleep(1)
+            await asyncio.sleep(1)
         elif self.current_play_style == IPlayingMode.AGGRESSIVE and self.possible_foe is None:
             self.move()
-            time.sleep(1)
+            await asyncio.sleep(1)
             self.attack()
-            time.sleep(1)
+            await asyncio.sleep(1)
         else:
             self.move()
-            time.sleep(1)
+            await asyncio.sleep(1)
         if self.current_play_style == IPlayingMode.DEFENSIVE:
             self.decide_best_defensive_action()
-            time.sleep(1)
+            await asyncio.sleep(1)
         self.communicator.informer.render(EventAction(event="search"))
         self.search_on_map()
-        time.sleep(1)
+        await asyncio.sleep(1)
         self.equip_item()

--- a/emberblast/communicator/__init__.py
+++ b/emberblast/communicator/__init__.py
@@ -1,4 +1,9 @@
-from .communicator import communicator_injector
+from .communicator import communicator_injector, create_textual_communicator
 from .level_up import improve_attributes_automatically, improve_attributes_randomly
 
-__all__ = ["improve_attributes_automatically", "improve_attributes_randomly", "communicator_injector"]
+__all__ = [
+    "improve_attributes_automatically",
+    "improve_attributes_randomly",
+    "communicator_injector",
+    "create_textual_communicator",
+]

--- a/emberblast/communicator/communicator.py
+++ b/emberblast/communicator/communicator.py
@@ -21,3 +21,17 @@ def communicator_factory() -> ICommunicator:
 
 
 communicator: ICommunicator = communicator_factory()
+
+
+def create_textual_communicator(app):
+    """Create a communicator wired to the Textual app."""
+    from emberblast.tui.questioner import TextualQuestioner
+    from emberblast.tui.renderer import TextualRenderer
+
+    class TextualCommunicator:
+        def __init__(self, app):
+            self.informer = TextualRenderer(app)
+            self.questioner = TextualQuestioner(app)
+            app.set_questioner(self.questioner)
+
+    return TextualCommunicator(app)

--- a/emberblast/communicator/questioner_cmd.py
+++ b/emberblast/communicator/questioner_cmd.py
@@ -1,3 +1,4 @@
+import asyncio
 from pathlib import Path
 from typing import Dict, List, Union
 
@@ -14,7 +15,7 @@ class QuestionerCMD(IQuestioningSystem):
     def __init__(self) -> None:
         super().__init__()
 
-    def ask_check_action(self, show_items: bool = False) -> Union[str, bool, list, str]:
+    async def ask_check_action(self, show_items: bool = False) -> Union[str, bool, list, str]:
         """
         Ask which kind of information player wants to check.
 
@@ -42,10 +43,10 @@ class QuestionerCMD(IQuestioningSystem):
                 "max_height": "100",
             }
         ]
-        result = prompt(questions=questions)
+        result = await asyncio.to_thread(prompt, questions=questions)
         return result[0]
 
-    def ask_actions_questions(self, actions_available: List[str]) -> Union[str, bool, list, str]:
+    async def ask_actions_questions(self, actions_available: List[str]) -> Union[str, bool, list, str]:
         base_actions = {
             "move": {"name": "Move \U0001f3c3", "value": "move"},
             "attack": {"name": "Attack \u2694\ufe0f", "value": "attack"},
@@ -74,11 +75,11 @@ class QuestionerCMD(IQuestioningSystem):
                 "max_height": "100",
             }
         ]
-        result = prompt(questions=actions_questions)
+        result = await asyncio.to_thread(prompt, questions=actions_questions)
         print("\033[A" + 100 * " " + "\033[A")  # ansi escape arrow up then overwrite the line
         return result[0]
 
-    def ask_enemy_to_check(self, enemies: List[IPlayer]) -> Union[str, bool, list, IPlayer]:
+    async def ask_enemy_to_check(self, enemies: List[IPlayer]) -> Union[str, bool, list, IPlayer]:
         choices = []
         for enemy in enemies:
             choices.append(
@@ -95,11 +96,13 @@ class QuestionerCMD(IQuestioningSystem):
             }
         ]
 
-        result = prompt(questions=enemies_questions)
+        result = await asyncio.to_thread(prompt, questions=enemies_questions)
         selected_enemy = result[0]
         return selected_enemy
 
-    def ask_enemy_to_attack(self, enemies: List[IPlayer], skill_type: str = "") -> Union[str, bool, list, IPlayer]:
+    async def ask_enemy_to_attack(
+        self, enemies: List[IPlayer], skill_type: str = ""
+    ) -> Union[str, bool, list, IPlayer]:
         choices = []
         action_type = "attack \U0001f44a"
 
@@ -130,11 +133,11 @@ class QuestionerCMD(IQuestioningSystem):
                 "max_height": "100",
             }
         ]
-        result = prompt(questions=enemies_questions)
+        result = await asyncio.to_thread(prompt, questions=enemies_questions)
         selected_enemy = result[0]
         return selected_enemy
 
-    def select_item(self, items: List[IItem]) -> Union[str, bool, list, IItem]:
+    async def select_item(self, items: List[IItem]) -> Union[str, bool, list, IItem]:
         choices = []
         for item in items:
             choices.append({"name": ("{item} - {tier}".format(item=item.name, tier=item.tier)), "value": item})
@@ -151,27 +154,27 @@ class QuestionerCMD(IQuestioningSystem):
             }
         ]
 
-        result = prompt(questions=items_questions)
+        result = await asyncio.to_thread(prompt, questions=items_questions)
         selected_item = result[0]
         return selected_item
 
-    def confirm_item_selection(self) -> Union[str, bool, list, bool]:
+    async def confirm_item_selection(self) -> Union[str, bool, list, bool]:
         questions = [
             {"type": "confirm", "message": "Are you sure?", "name": "confirm", "default": False},
         ]
-        result = prompt(questions)
+        result = await asyncio.to_thread(prompt, questions)
         confirm = result["confirm"]
         return confirm
 
-    def confirm_use_item_on_you(self) -> Union[str, bool, list, bool]:
+    async def confirm_use_item_on_you(self) -> Union[str, bool, list, bool]:
         questions = [
             {"type": "confirm", "message": "Are you using the item on yourself?", "name": "confirm", "default": False},
         ]
-        result = prompt(questions)
+        result = await asyncio.to_thread(prompt, questions)
         confirm = result["confirm"]
         return confirm
 
-    def display_equipment_choices(self, player: IPlayer) -> Union[str, bool, list, IEquipmentItem]:
+    async def display_equipment_choices(self, player: IPlayer) -> Union[str, bool, list, IEquipmentItem]:
         equipments = player.bag.get_equipments()
         choices = []
 
@@ -202,11 +205,11 @@ class QuestionerCMD(IQuestioningSystem):
             }
         ]
 
-        result = prompt(questions=equipment_questions)
+        result = await asyncio.to_thread(prompt, questions=equipment_questions)
         selected_equipment = result[0]
         return selected_equipment
 
-    def ask_attributes_to_improve(self) -> Union[str, bool, list, List]:
+    async def ask_attributes_to_improve(self) -> Union[str, bool, list, List]:
         level_up_increment_attributes = get_configuration(LEVEL_UP_INCREMENT)
         health_points = level_up_increment_attributes.get("health_points", 5)
         magic_points = level_up_increment_attributes.get("magic_points", 5)
@@ -269,10 +272,10 @@ class QuestionerCMD(IQuestioningSystem):
             },
         ]
 
-        result = prompt(questions=level_up_questions)
+        result = await asyncio.to_thread(prompt, questions=level_up_questions)
         return result[0]
 
-    def ask_where_to_move(self, possibilities: List[str]) -> Union[str, bool, list, str]:
+    async def ask_where_to_move(self, possibilities: List[str]) -> Union[str, bool, list, str]:
         questions = [
             {
                 "type": "list",
@@ -283,10 +286,10 @@ class QuestionerCMD(IQuestioningSystem):
                 "max_height": "100",
             }
         ]
-        result = prompt(questions=questions)
+        result = await asyncio.to_thread(prompt, questions=questions)
         return result[0]
 
-    def perform_first_question(self) -> Union[str, bool, list, str]:
+    async def perform_first_question(self) -> Union[str, bool, list, str]:
         choices = [
             {"name": "New Game \U0001f195", "value": "new"},
             {"name": "Continue \U0001f501", "value": "continue"},
@@ -302,10 +305,10 @@ class QuestionerCMD(IQuestioningSystem):
                 "max_height": "100",
             }
         ]
-        result = prompt(questions=first_game_questions)
+        result = await asyncio.to_thread(prompt, questions=first_game_questions)
         return result[0]
 
-    def perform_game_create_questions(self) -> Union[str, bool, list, dict]:
+    async def perform_game_create_questions(self) -> Union[str, bool, list, dict]:
         begin_game_questions = [
             {
                 "type": "list",
@@ -337,9 +340,9 @@ class QuestionerCMD(IQuestioningSystem):
             },
         ]
 
-        return prompt(begin_game_questions)
+        return await asyncio.to_thread(prompt, begin_game_questions)
 
-    def perform_character_creation_questions(self, existing_names: List[str]) -> Union[str, bool, list, dict]:
+    async def perform_character_creation_questions(self, existing_names: List[str]) -> Union[str, bool, list, dict]:
         questions = [
             {
                 "type": "input",
@@ -362,9 +365,9 @@ class QuestionerCMD(IQuestioningSystem):
             },
         ]
 
-        return prompt(questions)
+        return await asyncio.to_thread(prompt, questions)
 
-    def get_saved_game(self, normalized_files: List[Dict]) -> Union[str, bool, list, Path]:
+    async def get_saved_game(self, normalized_files: List[Dict]) -> Union[str, bool, list, Path]:
         choices = []
 
         for file_dict in normalized_files:
@@ -382,10 +385,10 @@ class QuestionerCMD(IQuestioningSystem):
                 "max_height": "100",
             }
         ]
-        result = prompt(questions=select_saved_game_questions)
+        result = await asyncio.to_thread(prompt, questions=select_saved_game_questions)
         return result[0]
 
-    def select_skill(self, available_skills: List[ISkill]) -> Union[str, bool, list, ISkill]:
+    async def select_skill(self, available_skills: List[ISkill]) -> Union[str, bool, list, ISkill]:
         choices = []
         for skill in available_skills:
             area_range_string = ""
@@ -420,7 +423,7 @@ class QuestionerCMD(IQuestioningSystem):
             }
         ]
 
-        result = prompt(questions=skill_questions)
+        result = await asyncio.to_thread(prompt, questions=skill_questions)
         selected_skill = result[0]
         return selected_skill
 

--- a/emberblast/game/game_factory.py
+++ b/emberblast/game/game_factory.py
@@ -23,7 +23,7 @@ class GameFactory(IGameFactory):
         """
         self.begin_question_results = None
 
-    def pre_initial_settings(self) -> IGameOrchestrator:
+    async def pre_initial_settings(self) -> IGameOrchestrator:
         """
         Executes the first game communicator, checking if the player wants
         to create a new game, or load an existing one.
@@ -34,18 +34,18 @@ class GameFactory(IGameFactory):
 
         # Checking first if there are any saved games
         if len(normalized_files) > 0:
-            first_game_question = self.communicator.questioner.perform_first_question()
+            first_game_question = await self.communicator.questioner.perform_first_question()
             if first_game_question == "new":
-                return self.new_game()
+                return await self.new_game()
             elif first_game_question == "continue":
                 normalized_files = get_normalized_saved_files_dict()
-                selected_file = self.communicator.questioner.get_saved_game(normalized_files)
+                selected_file = await self.communicator.questioner.get_saved_game(normalized_files)
                 game_orchestrator = recover_saved_game_orchestrator(selected_file)
                 return game_orchestrator
         else:
-            return self.new_game()
+            return await self.new_game()
 
-    def new_game(self) -> IGameOrchestrator:
+    async def new_game(self) -> IGameOrchestrator:
         """
         Creates a new game, prompting the user the necessary communicator of how the game will be, and
         instantiate the proper objects, according to what was requested.
@@ -53,8 +53,8 @@ class GameFactory(IGameFactory):
         :rtype: IGameOrchestrator.
         """
         players = []
-        self.begin_question_results = self.communicator.questioner.perform_game_create_questions()
-        controlled_players = self.init_players()
+        self.begin_question_results = await self.communicator.questioner.perform_game_create_questions()
+        controlled_players = await self.init_players()
         players.extend(controlled_players)
 
         bots = self.init_bots()
@@ -79,7 +79,7 @@ class GameFactory(IGameFactory):
         """
         return MapFactory().create_map(map_size)
 
-    def init_players(self) -> List[IControlledPlayer]:
+    async def init_players(self) -> List[IControlledPlayer]:
         """
         Method used for generating the controlled players.
 
@@ -93,7 +93,9 @@ class GameFactory(IGameFactory):
             self.communicator.informer.render(NewCharacterEvent(number=i))
             existing_names = [x for x in map(lambda player: player.name, controlled_players)]
 
-            new_character_responses = self.communicator.questioner.perform_character_creation_questions(existing_names)
+            new_character_responses = await self.communicator.questioner.perform_character_creation_questions(
+                existing_names
+            )
             controlled_player = ControlledPlayer(
                 new_character_responses.get("nickname"),
                 dynamic_jobs_classes[new_character_responses.get("job")](),

--- a/emberblast/interface/interface.py
+++ b/emberblast/interface/interface.py
@@ -494,7 +494,7 @@ class IPlayingMode(Enum):
 
 class IQuestioningSystem(ABC):
     @abstractmethod
-    def ask_check_action(self, show_items: bool = False) -> Union[str, bool, list, str]:
+    async def ask_check_action(self, show_items: bool = False) -> Union[str, bool, list, str]:
         """
         Ask which kind of information player wants to check.
 
@@ -505,7 +505,7 @@ class IQuestioningSystem(ABC):
         pass
 
     @abstractmethod
-    def ask_actions_questions(self, actions_available: List[str]) -> Union[str, bool, list, str]:
+    async def ask_actions_questions(self, actions_available: List[str]) -> Union[str, bool, list, str]:
         """
         Ask which action the player is going to execute.
 
@@ -515,7 +515,7 @@ class IQuestioningSystem(ABC):
         pass
 
     @abstractmethod
-    def ask_enemy_to_check(self, enemies: List[IPlayer]) -> Union[str, bool, list, IPlayer]:
+    async def ask_enemy_to_check(self, enemies: List[IPlayer]) -> Union[str, bool, list, IPlayer]:
         """
         Ask which enemy the player wants to know more info.
 
@@ -525,7 +525,9 @@ class IQuestioningSystem(ABC):
         pass
 
     @abstractmethod
-    def ask_enemy_to_attack(self, enemies: List[IPlayer], skill_type: str = "") -> Union[str, bool, list, IPlayer]:
+    async def ask_enemy_to_attack(
+        self, enemies: List[IPlayer], skill_type: str = ""
+    ) -> Union[str, bool, list, IPlayer]:
         """
         Ask which enemy to attack.
 
@@ -536,7 +538,7 @@ class IQuestioningSystem(ABC):
         pass
 
     @abstractmethod
-    def select_item(self, items: List[IItem]) -> Union[str, bool, list, IItem]:
+    async def select_item(self, items: List[IItem]) -> Union[str, bool, list, IItem]:
         """
         Select an item to use, or even get more information about it.
 
@@ -546,7 +548,7 @@ class IQuestioningSystem(ABC):
         pass
 
     @abstractmethod
-    def confirm_item_selection(self) -> Union[str, bool, list, bool]:
+    async def confirm_item_selection(self) -> Union[str, bool, list, bool]:
         """
         Confirm question, to ensure that player really wants to use the selected item.
 
@@ -555,7 +557,7 @@ class IQuestioningSystem(ABC):
         pass
 
     @abstractmethod
-    def confirm_use_item_on_you(self) -> Union[str, bool, list, bool]:
+    async def confirm_use_item_on_you(self) -> Union[str, bool, list, bool]:
         """
         Confirm question, to ensure that player really wants to use the selected item on himself.
 
@@ -564,7 +566,7 @@ class IQuestioningSystem(ABC):
         pass
 
     @abstractmethod
-    def display_equipment_choices(self, player: IPlayer) -> Union[str, bool, list, IEquipmentItem]:
+    async def display_equipment_choices(self, player: IPlayer) -> Union[str, bool, list, IEquipmentItem]:
         """
         Will display all the equipments that player has, for equipping one of them.
 
@@ -574,7 +576,7 @@ class IQuestioningSystem(ABC):
         pass
 
     @abstractmethod
-    def ask_attributes_to_improve(self) -> Union[str, bool, list, List]:
+    async def ask_attributes_to_improve(self) -> Union[str, bool, list, List]:
         """
         This function is used by human controlled players to chose which attribute they want to upgrade
 
@@ -583,7 +585,7 @@ class IQuestioningSystem(ABC):
         pass
 
     @abstractmethod
-    def ask_where_to_move(self, possibilities: List[str]) -> Union[str, bool, list, str]:
+    async def ask_where_to_move(self, possibilities: List[str]) -> Union[str, bool, list, str]:
         """
         This function is used by asking the player where he wants to move.
 
@@ -593,7 +595,7 @@ class IQuestioningSystem(ABC):
         pass
 
     @abstractmethod
-    def perform_first_question(self) -> Union[str, bool, list, str]:
+    async def perform_first_question(self) -> Union[str, bool, list, str]:
         """
         This function is used by asking a new game communicator.
 
@@ -602,7 +604,7 @@ class IQuestioningSystem(ABC):
         pass
 
     @abstractmethod
-    def perform_game_create_questions(self) -> Union[str, bool, list, dict]:
+    async def perform_game_create_questions(self) -> Union[str, bool, list, dict]:
         """
         This function is used by asking a new game communicator.
 
@@ -611,7 +613,7 @@ class IQuestioningSystem(ABC):
         pass
 
     @abstractmethod
-    def select_skill(self, available_skills: List[ISkill]) -> Union[str, bool, list, ISkill]:
+    async def select_skill(self, available_skills: List[ISkill]) -> Union[str, bool, list, ISkill]:
         """
         Question function, to query user for available skills to use.
 
@@ -621,7 +623,7 @@ class IQuestioningSystem(ABC):
         pass
 
     @abstractmethod
-    def get_saved_game(self, normalized_files: List[Dict]) -> Union[str, bool, list, Path]:
+    async def get_saved_game(self, normalized_files: List[Dict]) -> Union[str, bool, list, Path]:
         """
         Ask the players, which load file he wants to continue playing, the saved games comes in the normalized_files
         parameter, that it's a list of dictionaries that has the file itself, and also a normalized user friendly
@@ -633,7 +635,7 @@ class IQuestioningSystem(ABC):
         pass
 
     @abstractmethod
-    def perform_character_creation_questions(self, existing_names: List[str]) -> Union[str, bool, list, dict]:
+    async def perform_character_creation_questions(self, existing_names: List[str]) -> Union[str, bool, list, dict]:
         """
         This function is used when creating a new character.
 
@@ -673,7 +675,7 @@ class IGameOrchestrator:
         pass
 
     @abstractmethod
-    def execute_game(self) -> None:
+    async def execute_game(self) -> None:
         pass
 
     @abstractmethod
@@ -694,11 +696,11 @@ class IGameFactory:
     communicator: ICommunicator
 
     @abstractmethod
-    def pre_initial_settings(self) -> IGameOrchestrator:
+    async def pre_initial_settings(self) -> IGameOrchestrator:
         pass
 
     @abstractmethod
-    def new_game(self) -> IGameOrchestrator:
+    async def new_game(self) -> IGameOrchestrator:
         pass
 
     @abstractmethod
@@ -706,7 +708,7 @@ class IGameFactory:
         pass
 
     @abstractmethod
-    def init_players(self) -> IControlledPlayer:
+    async def init_players(self) -> IControlledPlayer:
         pass
 
     @abstractmethod
@@ -718,5 +720,5 @@ class IEmberblast(ABC):
     communicator: ICommunicator
 
     @abstractmethod
-    def run(self) -> None:
+    async def run(self) -> None:
         pass

--- a/emberblast/orchestrator/game_orchestrator.py
+++ b/emberblast/orchestrator/game_orchestrator.py
@@ -680,6 +680,3 @@ class DeathMatchOrchestrator(GameOrchestrator):
             self.communicator.informer.render(CheckItemEvent(item=item))
         else:
             return
-
-    async def pass_turn(self, player: IPlayer) -> Optional[bool]:
-        pass

--- a/emberblast/orchestrator/game_orchestrator.py
+++ b/emberblast/orchestrator/game_orchestrator.py
@@ -1,6 +1,6 @@
+import asyncio
 import math
 import random
-import time
 from os import system
 from typing import List, Optional
 
@@ -85,7 +85,7 @@ class GameOrchestrator(IGameOrchestrator):
         self.actions["check"]: IAction = {"independent": True, "repeatable": True, "function": self.check}
         self.actions["pass"]: IAction = {"independent": True, "repeatable": False, "function": self.pass_turn}
 
-    def execute_game(self) -> None:
+    async def execute_game(self) -> None:
         """
         This method should be implement by Styles of Games that Inherits from this superclass.
 
@@ -104,47 +104,47 @@ class GameOrchestrator(IGameOrchestrator):
         for player in self.game.get_all_players():
             player.refresh_skills_list()
 
-    def check_player_level_up(self, player: IPlayer) -> None:
+    async def check_player_level_up(self, player: IPlayer) -> None:
         if player.experience >= 100:
             player.experience = player.experience - 100
             if isinstance(player, IControlledPlayer):
-                attributes = self.communicator.questioner.ask_attributes_to_improve()
+                attributes = await self.communicator.questioner.ask_attributes_to_improve()
             else:
                 attributes = improve_attributes_automatically(player.job.get_name(), player.race.get_name())
             player.level_up(attributes)
             self.communicator.informer.render(LevelUpEvent(player_name=player.name, new_level=player.level))
 
-    def move(self, player: IPlayer) -> Optional[bool]:
+    async def move(self, player: IPlayer) -> Optional[bool]:
         pass
 
-    def defend(self, player: IPlayer) -> Optional[bool]:
+    async def defend(self, player: IPlayer) -> Optional[bool]:
         pass
 
-    def hide(self, player: IPlayer) -> Optional[bool]:
+    async def hide(self, player: IPlayer) -> Optional[bool]:
         pass
 
-    def search(self, player: IPlayer) -> Optional[bool]:
+    async def search(self, player: IPlayer) -> Optional[bool]:
         pass
 
-    def attack(self, player: IPlayer) -> Optional[bool]:
+    async def attack(self, player: IPlayer) -> Optional[bool]:
         pass
 
-    def skill(self, player: IPlayer) -> Optional[bool]:
+    async def skill(self, player: IPlayer) -> Optional[bool]:
         pass
 
-    def item(self, player: IPlayer) -> Optional[bool]:
+    async def item(self, player: IPlayer) -> Optional[bool]:
         pass
 
-    def drop(self, player: IPlayer) -> Optional[bool]:
+    async def drop(self, player: IPlayer) -> Optional[bool]:
         pass
 
-    def equip(self, player: IPlayer) -> Optional[bool]:
+    async def equip(self, player: IPlayer) -> Optional[bool]:
         pass
 
-    def check(self, player: IPlayer) -> Optional[bool]:
+    async def check(self, player: IPlayer) -> Optional[bool]:
         pass
 
-    def pass_turn(self, player: IPlayer) -> Optional[bool]:
+    async def pass_turn(self, player: IPlayer) -> Optional[bool]:
         pass
 
     def check_iterated_side_effects(self, player: IPlayer) -> None:
@@ -207,7 +207,7 @@ class DeathMatchOrchestrator(GameOrchestrator):
         memory = self.bot_controller._get_memory(player_name)
         memory.add(turn, description)
 
-    def execute_game(self) -> None:
+    async def execute_game(self) -> None:
         """
         The implementation of the superclass method,which is the one for executing each of the calculated turns of
         the game. It's the same method to start a newly created game or a continue.
@@ -222,7 +222,7 @@ class DeathMatchOrchestrator(GameOrchestrator):
             turn_list = [list(self.game.turns.copy().keys())[-1]]
             self.clear()
             self.communicator.informer.render(LineSeparatorEvent())
-            time.sleep(3)
+            await asyncio.sleep(3)
 
             for turn in turn_list:
                 self.clear()
@@ -246,10 +246,10 @@ class DeathMatchOrchestrator(GameOrchestrator):
                     # Resetting player's last action, If he was defending or hidden, this will be reset for a new turn
                     player.reset_last_action()
                     if isinstance(player, IControlledPlayer):
-                        self.controlled_decisioning(player)
+                        await self.controlled_decisioning(player)
                     else:
-                        time.sleep(random.randint(2, 4))
-                        self.bot_decisioning(player)
+                        await asyncio.sleep(random.randint(2, 4))
+                        await self.bot_decisioning(player)
                     self.turn_remaining_players.remove(player)
 
                 alive_players = self.game.get_all_alive_players()
@@ -263,7 +263,7 @@ class DeathMatchOrchestrator(GameOrchestrator):
         except Exception as err:
             print(err)
 
-    def bot_decisioning(self, player: IPlayer) -> None:
+    async def bot_decisioning(self, player: IPlayer) -> None:
         """
         Function that controls bot decisions over a IA.
 
@@ -272,14 +272,14 @@ class DeathMatchOrchestrator(GameOrchestrator):
         """
         self.check_iterated_side_effects(player)
         try:
-            self.bot_controller.decide(player)
+            await self.bot_controller.decide(player)
 
         except Exception as err:
             print(err)
             print("System shutdown with unexpected error")
 
         self.check_side_effect_duration(player)
-        self.check_player_level_up(player)
+        await self.check_player_level_up(player)
 
         turn = self.bot_controller._current_turn
         self._record_bot_memory(
@@ -311,7 +311,7 @@ class DeathMatchOrchestrator(GameOrchestrator):
 
         return valid_actions
 
-    def controlled_decisioning(self, player: IControlledPlayer) -> None:
+    async def controlled_decisioning(self, player: IControlledPlayer) -> None:
         """
         The function for controlled players to decide which actions they are going to execute each turn.
 
@@ -322,14 +322,16 @@ class DeathMatchOrchestrator(GameOrchestrator):
         self.check_iterated_side_effects(player)
 
         while len(self.actions_left) > 2:
-            chosen_action_string = self.communicator.questioner.ask_actions_questions(self.hide_invalid_actions(player))
+            chosen_action_string = await self.communicator.questioner.ask_actions_questions(
+                self.hide_invalid_actions(player)
+            )
             action = self.actions[chosen_action_string]
             action_function = action["function"]
-            if action_function(player) is None:
+            if await action_function(player) is None:
                 self.compute_player_decisions(action, chosen_action_string)
         else:
             self.check_side_effect_duration(player)
-            self.check_player_level_up(player)
+            await self.check_player_level_up(player)
 
     def compute_player_decisions(self, action: IAction, action_string: str) -> None:
         """
@@ -350,7 +352,7 @@ class DeathMatchOrchestrator(GameOrchestrator):
                 if not value["independent"]:
                     self.actions_left.remove(key)
 
-    def move(self, player: IPlayer) -> Optional[bool]:
+    async def move(self, player: IPlayer) -> Optional[bool]:
         move_speed = player.get_attribute_real_value("move_speed")
         possibilities = self.game.game_map.graph.get_available_nodes_in_range(player.position, move_speed)
         self.communicator.informer.render(
@@ -361,17 +363,17 @@ class DeathMatchOrchestrator(GameOrchestrator):
                 size=self.game.game_map.size,
             )
         )
-        selected_place = self.communicator.questioner.ask_where_to_move(possibilities)
+        selected_place = await self.communicator.questioner.ask_where_to_move(possibilities)
         self.game.game_map.move_player(player, selected_place)
         self.communicator.informer.render(EventAction(event="move"))
         self.communicator.informer.render(MoveEvent(player_name=player.name))
         return
 
-    def defend(self, player: IPlayer) -> Optional[bool]:
+    async def defend(self, player: IPlayer) -> Optional[bool]:
         player.set_defense_mode(True)
         return
 
-    def hide(self, player: IPlayer) -> Optional[bool]:
+    async def hide(self, player: IPlayer) -> Optional[bool]:
         current_accuracy = player.get_attribute_real_value("accuracy")
         additional = (current_accuracy / 5 * 10) / 100
 
@@ -379,10 +381,10 @@ class DeathMatchOrchestrator(GameOrchestrator):
         player.set_hidden(result)
         return
 
-    def search(self, player: IPlayer) -> Optional[bool]:
+    async def search(self, player: IPlayer) -> Optional[bool]:
         self.communicator.informer.render(EventAction(event="search"))
         items = self.game.game_map.check_item_in_position(player.position)
-        time.sleep(2)
+        await asyncio.sleep(2)
         if items is not None:
             for item in items:
                 player.bag.add_item(item)
@@ -444,7 +446,7 @@ class DeathMatchOrchestrator(GameOrchestrator):
 
         return possible_foes
 
-    def attack(self, player: IPlayer) -> Optional[bool]:
+    async def attack(self, player: IPlayer) -> Optional[bool]:
         players = self.game.get_remaining_players(player)
         attack_range = player.get_ranged_attack_area()
         possible_foes = self.get_attack_possibilities(attack_range, player, players)
@@ -456,10 +458,10 @@ class DeathMatchOrchestrator(GameOrchestrator):
                 )
             )
             return False
-        enemy_to_attack = self.communicator.questioner.ask_enemy_to_attack(possible_foes)
+        enemy_to_attack = await self.communicator.questioner.ask_enemy_to_attack(possible_foes)
         if enemy_to_attack is None:
             return False
-        time.sleep(2)
+        await asyncio.sleep(2)
         self.communicator.informer.render(EventAction(event="attack"))
         dice_result = self.game.roll_the_dice()
         self.communicator.informer.render(
@@ -472,7 +474,7 @@ class DeathMatchOrchestrator(GameOrchestrator):
         )
 
         damage = self.calculate_damage(player, enemy_to_attack, dice_result)
-        self.check_player_level_up(player)
+        await self.check_player_level_up(player)
         turn = self.bot_controller._current_turn
         if damage > 0:
             enemy_to_attack.suffer_damage(damage)
@@ -526,7 +528,7 @@ class DeathMatchOrchestrator(GameOrchestrator):
 
         return area_foes
 
-    def skill(self, player: IPlayer) -> Optional[bool]:
+    async def skill(self, player: IPlayer) -> Optional[bool]:
         foes = []
         possible_foes = []
 
@@ -535,7 +537,7 @@ class DeathMatchOrchestrator(GameOrchestrator):
             self.communicator.informer.render(LowManaEvent(player_name=player.name, mana=player.mana))
 
         available_skills = get_player_available_skills(player)
-        selected_skill = self.communicator.questioner.select_skill(available_skills)
+        selected_skill = await self.communicator.questioner.select_skill(available_skills)
         remaining_players = self.game.get_remaining_players(player)
         if selected_skill is None:
             return False
@@ -556,7 +558,7 @@ class DeathMatchOrchestrator(GameOrchestrator):
                 )
             )
             return False
-        enemy_to_attack = self.communicator.questioner.ask_enemy_to_attack(possible_foes, selected_skill.kind)
+        enemy_to_attack = await self.communicator.questioner.ask_enemy_to_attack(possible_foes, selected_skill.kind)
         if enemy_to_attack is None:
             return False
         if selected_skill.area > 0:
@@ -569,7 +571,7 @@ class DeathMatchOrchestrator(GameOrchestrator):
                 )
         else:
             foes.append(enemy_to_attack)
-        time.sleep(2)
+        await asyncio.sleep(2)
         self.communicator.informer.render(EventAction(event="skill"))
         dice_result = self.game.roll_the_dice()
         self.communicator.informer.render(
@@ -599,18 +601,18 @@ class DeathMatchOrchestrator(GameOrchestrator):
                 )
         return
 
-    def item(self, player: IPlayer) -> Optional[bool]:
+    async def item(self, player: IPlayer) -> Optional[bool]:
         using_player = player.name
         usable_items = player.bag.get_usable_items()
-        selected_item = self.communicator.questioner.select_item(usable_items)
+        selected_item = await self.communicator.questioner.select_item(usable_items)
         if selected_item is None:
             return False
         another_players_in_position = self.game.check_another_players_in_position(player)
         if len(another_players_in_position) > 0:
-            if not self.communicator.questioner.confirm_use_item_on_you():
-                player = self.communicator.questioner.ask_enemy_to_attack(another_players_in_position)
-        if self.communicator.questioner.confirm_item_selection():
-            time.sleep(2)
+            if not await self.communicator.questioner.confirm_use_item_on_you():
+                player = await self.communicator.questioner.ask_enemy_to_attack(another_players_in_position)
+        if await self.communicator.questioner.confirm_item_selection():
+            await asyncio.sleep(2)
             self.communicator.informer.render(EventAction(event="item"))
             target_player = player.name
             player.use_item(selected_item)
@@ -627,11 +629,11 @@ class DeathMatchOrchestrator(GameOrchestrator):
         else:
             return True
 
-    def drop(self, player: IPlayer) -> Optional[bool]:
-        selected_item = self.communicator.questioner.select_item(player.bag.items)
+    async def drop(self, player: IPlayer) -> Optional[bool]:
+        selected_item = await self.communicator.questioner.select_item(player.bag.items)
         if selected_item is None:
             return False
-        confirm = self.communicator.questioner.confirm_item_selection()
+        confirm = await self.communicator.questioner.confirm_item_selection()
         if confirm:
             if isinstance(selected_item, IEquipmentItem):
                 player.remove_side_effects(selected_item.side_effects)
@@ -640,8 +642,8 @@ class DeathMatchOrchestrator(GameOrchestrator):
             self.game.game_map.add_item_to_map(player.position, selected_item)
         return
 
-    def equip(self, player: IPlayer) -> Optional[bool]:
-        equipment_item = self.communicator.questioner.display_equipment_choices(player)
+    async def equip(self, player: IPlayer) -> Optional[bool]:
+        equipment_item = await self.communicator.questioner.display_equipment_choices(player)
         if equipment_item is None:
             return False
         if player.equipment.is_equipped(equipment_item):
@@ -653,8 +655,8 @@ class DeathMatchOrchestrator(GameOrchestrator):
         player.side_effects.extend(equipment_item.side_effects)
         return
 
-    def check(self, player: IPlayer) -> Optional[bool]:
-        check_option = self.communicator.questioner.ask_check_action(
+    async def check(self, player: IPlayer) -> Optional[bool]:
+        check_option = await self.communicator.questioner.ask_check_action(
             show_items=True if len(player.bag.items) > 0 else False
         )
         if check_option == "status":
@@ -671,10 +673,13 @@ class DeathMatchOrchestrator(GameOrchestrator):
             )
         elif check_option == "enemy":
             enemies = self.game.get_remaining_players(player, include_hidden=False)
-            enemy = self.communicator.questioner.ask_enemy_to_check(enemies)
+            enemy = await self.communicator.questioner.ask_enemy_to_check(enemies)
             self.communicator.informer.render(EnemyStatusEvent(enemy=enemy))
         elif check_option == "item":
-            item = self.communicator.questioner.select_item(player.bag.items)
+            item = await self.communicator.questioner.select_item(player.bag.items)
             self.communicator.informer.render(CheckItemEvent(item=item))
         else:
             return
+
+    async def pass_turn(self, player: IPlayer) -> Optional[bool]:
+        pass

--- a/emberblast/test/test_action_bar_widget.py
+++ b/emberblast/test/test_action_bar_widget.py
@@ -30,8 +30,8 @@ class TestActionBarWidget(BaseTestCase):
         self.widget.set_actions(["move", "attack"])
         text = self.widget._build_bar_text()
         plain = text.plain
-        self.assertIn("move", plain.lower())
-        self.assertIn("attack", plain.lower())
+        self.assertIn("ove", plain)  # [M]ove
+        self.assertIn("ttack", plain)  # [A]ttack
 
     def test_clear_resets_state(self):
         self.widget.set_actions(["move", "attack"])
@@ -49,3 +49,10 @@ class TestActionBarWidget(BaseTestCase):
         self.widget.set_status("Waiting...")
         text = self.widget._build_bar_text()
         self.assertIn("Waiting...", text.plain)
+
+    def test_bordered_buttons_have_box_chars(self):
+        self.widget.set_actions(["move"])
+        text = self.widget._build_bar_text()
+        plain = text.plain
+        self.assertIn("\u250c", plain)  # top-left corner
+        self.assertIn("\u2518", plain)  # bottom-right corner

--- a/emberblast/test/test_action_bar_widget.py
+++ b/emberblast/test/test_action_bar_widget.py
@@ -1,0 +1,51 @@
+"""Tests for the ActionBar widget."""
+
+from emberblast.test.test import BaseTestCase
+from emberblast.tui.widgets.action_bar import ActionBarWidget
+
+
+class TestActionBarWidget(BaseTestCase):
+    """Tests for the ActionBar widget."""
+
+    def setUp(self):
+        self.widget = ActionBarWidget()
+
+    def test_set_actions_stores_actions(self):
+        self.widget.set_actions(["move", "attack", "defend"])
+        self.assertEqual(self.widget._actions, ["move", "attack", "defend"])
+
+    def test_set_status_stores_text(self):
+        self.widget.set_status("Waiting for input...")
+        self.assertEqual(self.widget._status, "Waiting for input...")
+
+    def test_build_bar_text_contains_keys(self):
+        self.widget.set_actions(["move", "attack", "skill"])
+        text = self.widget._build_bar_text()
+        plain = text.plain
+        self.assertIn("[M]", plain)
+        self.assertIn("[A]", plain)
+        self.assertIn("[S]", plain)
+
+    def test_build_bar_text_contains_action_names(self):
+        self.widget.set_actions(["move", "attack"])
+        text = self.widget._build_bar_text()
+        plain = text.plain
+        self.assertIn("move", plain.lower())
+        self.assertIn("attack", plain.lower())
+
+    def test_clear_resets_state(self):
+        self.widget.set_actions(["move", "attack"])
+        self.widget.set_status("Some status")
+        self.widget.clear()
+        self.assertEqual(self.widget._actions, [])
+        self.assertEqual(self.widget._status, "")
+
+    def test_status_appears_in_bar(self):
+        self.widget.set_status("Enemy turn...")
+        text = self.widget._build_bar_text()
+        self.assertIn("Enemy turn...", text.plain)
+
+    def test_empty_actions_shows_status_only(self):
+        self.widget.set_status("Waiting...")
+        text = self.widget._build_bar_text()
+        self.assertIn("Waiting...", text.plain)

--- a/emberblast/test/test_battle_screen.py
+++ b/emberblast/test/test_battle_screen.py
@@ -1,0 +1,52 @@
+"""Tests for BattleScreen."""
+
+from emberblast.test.test import BaseTestCase
+from emberblast.tui.screens.battle import _KEY_TO_ACTION, BattleScreen, TurnHeader
+from emberblast.tui.widgets.action_bar import ACTION_KEYS
+
+
+class TestBattleScreenStructure(BaseTestCase):
+    """Verify BattleScreen has the expected class structure."""
+
+    def test_battle_screen_has_compose(self):
+        self.assertHasAttr(BattleScreen, "compose")
+
+    def test_battle_screen_has_set_questioner(self):
+        self.assertHasAttr(BattleScreen, "set_questioner")
+
+    def test_battle_screen_has_show_actions(self):
+        self.assertHasAttr(BattleScreen, "show_actions")
+
+    def test_battle_screen_has_show_choices(self):
+        self.assertHasAttr(BattleScreen, "show_choices")
+
+    def test_battle_screen_has_show_confirm(self):
+        self.assertHasAttr(BattleScreen, "show_confirm")
+
+    def test_battle_screen_has_on_key(self):
+        self.assertHasAttr(BattleScreen, "on_key")
+
+    def test_turn_header_has_set_turn(self):
+        self.assertHasAttr(TurnHeader, "set_turn")
+
+    def test_turn_header_has_set_map_name(self):
+        self.assertHasAttr(TurnHeader, "set_map_name")
+
+
+class TestActionKeysCompleteness(BaseTestCase):
+    """Verify ACTION_KEYS covers all expected actions and reverse map is consistent."""
+
+    def test_all_action_keys_have_reverse_mapping(self):
+        """Every action in ACTION_KEYS should be reachable via _KEY_TO_ACTION."""
+        for action, key in ACTION_KEYS.items():
+            self.assertIn(key.lower(), _KEY_TO_ACTION)
+            self.assertEqual(_KEY_TO_ACTION[key.lower()], action)
+
+    def test_reverse_map_size_matches(self):
+        """Reverse map should have same number of entries as ACTION_KEYS (assuming unique keys)."""
+        self.assertEqual(len(_KEY_TO_ACTION), len(ACTION_KEYS))
+
+    def test_expected_actions_present(self):
+        expected = ["move", "attack", "skill", "defend", "item", "hide", "search", "equip", "drop", "check", "pass"]
+        for action in expected:
+            self.assertIn(action, ACTION_KEYS, f"Missing action: {action}")

--- a/emberblast/test/test_bot_decisioning.py
+++ b/emberblast/test/test_bot_decisioning.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from emberblast.bot import BotDecisioning
 
 from .test import BaseTestCase, manual_test
@@ -13,5 +15,4 @@ class TestModuleBot(BaseTestCase):
     def test_bot_turn_decision(self) -> None:
         self.mock_game.game_map.define_player_initial_position_random(self.mock_game.get_all_players())
         bot_decisioning = BotDecisioning(self.mock_game)
-        bot_decisioning.decide(self.mock_game.players[0])
-        pass
+        asyncio.run(bot_decisioning.decide(self.mock_game.players[0]))

--- a/emberblast/test/test_character_badge.py
+++ b/emberblast/test/test_character_badge.py
@@ -23,6 +23,7 @@ def _make_player(
     move_speed=3,
     will=7,
     position=None,
+    experience=42,
 ):
     p = MagicMock()
     p.name = name
@@ -41,7 +42,9 @@ def _make_player(
     p.move_speed = move_speed
     p.will = will
     p.position = position or [0, 0]
+    p.experience = experience
     p.side_effects = []
+    p.equipment = None
     return p
 
 
@@ -74,27 +77,31 @@ class TestCharacterBadgeWidget(BaseTestCase):
         player = _make_player(life=80, health_points=100)
         self.widget.update_player(player)
         text = self.widget._build_badge_text()
-        self.assertIn("80", text.plain)
-        self.assertIn("100", text.plain)
+        self.assertIn("80/100", text.plain)
 
     def test_mp_values_appear(self):
         player = _make_player(mana=30, magic_points=50)
         self.widget.update_player(player)
         text = self.widget._build_badge_text()
-        self.assertIn("30", text.plain)
-        self.assertIn("50", text.plain)
+        self.assertIn("30/50", text.plain)
+
+    def test_xp_appears(self):
+        player = _make_player(experience=42)
+        self.widget.update_player(player)
+        text = self.widget._build_badge_text()
+        self.assertIn("42/100", text.plain)
 
     def test_all_stats_appear(self):
         player = _make_player()
         self.widget.update_player(player)
         text = self.widget._build_badge_text()
         plain = text.plain
-        for stat in ("STR", "INT", "ACC", "ARM", "RES", "SPD", "WILL"):
+        for stat in ("STR", "INT", "ACC", "ARM", "RES", "SPD", "WIL"):
             self.assertIn(stat, plain)
 
     def test_no_player_shows_placeholder(self):
         text = self.widget._build_badge_text()
-        self.assertIn("No player", text.plain)
+        self.assertIn("Awaiting", text.plain)
 
     def test_zero_hp_renders(self):
         player = _make_player(life=0, health_points=100)

--- a/emberblast/test/test_character_badge.py
+++ b/emberblast/test/test_character_badge.py
@@ -1,0 +1,103 @@
+"""Tests for the CharacterBadgeWidget."""
+
+from unittest.mock import MagicMock
+
+from emberblast.test.test import BaseTestCase
+from emberblast.tui.widgets.character_badge import CharacterBadgeWidget
+
+
+def _make_player(
+    name="Hero",
+    job_name="Warrior",
+    race_name="Human",
+    level=5,
+    life=80,
+    health_points=100,
+    mana=30,
+    magic_points=50,
+    strength=15,
+    intelligence=10,
+    accuracy=12,
+    armour=8,
+    magic_resist=6,
+    move_speed=3,
+    will=7,
+    position=None,
+):
+    p = MagicMock()
+    p.name = name
+    p.job.name = job_name
+    p.race.name = race_name
+    p.level = level
+    p.life = life
+    p.health_points = health_points
+    p.mana = mana
+    p.magic_points = magic_points
+    p.strength = strength
+    p.intelligence = intelligence
+    p.accuracy = accuracy
+    p.armour = armour
+    p.magic_resist = magic_resist
+    p.move_speed = move_speed
+    p.will = will
+    p.position = position or [0, 0]
+    p.side_effects = []
+    return p
+
+
+class TestCharacterBadgeWidget(BaseTestCase):
+    """Tests for the CharacterBadgeWidget."""
+
+    def setUp(self):
+        self.widget = CharacterBadgeWidget()
+
+    def test_name_appears(self):
+        player = _make_player(name="Gandalf")
+        self.widget.update_player(player)
+        text = self.widget._build_badge_text()
+        self.assertIn("Gandalf", text.plain)
+
+    def test_job_and_race_appear(self):
+        player = _make_player(job_name="Wizard", race_name="Elf")
+        self.widget.update_player(player)
+        text = self.widget._build_badge_text()
+        self.assertIn("Wizard", text.plain)
+        self.assertIn("Elf", text.plain)
+
+    def test_level_appears(self):
+        player = _make_player(level=7)
+        self.widget.update_player(player)
+        text = self.widget._build_badge_text()
+        self.assertIn("Lv.7", text.plain)
+
+    def test_hp_values_appear(self):
+        player = _make_player(life=80, health_points=100)
+        self.widget.update_player(player)
+        text = self.widget._build_badge_text()
+        self.assertIn("80", text.plain)
+        self.assertIn("100", text.plain)
+
+    def test_mp_values_appear(self):
+        player = _make_player(mana=30, magic_points=50)
+        self.widget.update_player(player)
+        text = self.widget._build_badge_text()
+        self.assertIn("30", text.plain)
+        self.assertIn("50", text.plain)
+
+    def test_all_stats_appear(self):
+        player = _make_player()
+        self.widget.update_player(player)
+        text = self.widget._build_badge_text()
+        plain = text.plain
+        for stat in ("STR", "INT", "ACC", "ARM", "RES", "SPD", "WILL"):
+            self.assertIn(stat, plain)
+
+    def test_no_player_shows_placeholder(self):
+        text = self.widget._build_badge_text()
+        self.assertIn("No player", text.plain)
+
+    def test_zero_hp_renders(self):
+        player = _make_player(life=0, health_points=100)
+        self.widget.update_player(player)
+        text = self.widget._build_badge_text()
+        self.assertIn("0/100", text.plain)

--- a/emberblast/test/test_combat_log_widget.py
+++ b/emberblast/test/test_combat_log_widget.py
@@ -13,14 +13,18 @@ class TestCombatLogWidget(BaseTestCase):
     def test_add_entry_stores_message(self):
         self.widget.add_entry("Player attacked!", "damage")
         self.assertEqual(len(self.widget._entries), 1)
-        self.assertEqual(self.widget._entries[0], ("Player attacked!", "damage"))
+        msg, cat, turn = self.widget._entries[0]
+        self.assertEqual(msg, "Player attacked!")
+        self.assertEqual(cat, "damage")
 
     def test_max_entries_respected(self):
         for i in range(10):
             self.widget.add_entry(f"Message {i}", "system")
         self.assertEqual(len(self.widget._entries), 5)
         # Oldest entries should be gone, newest should remain
-        self.assertEqual(self.widget._entries[0], ("Message 5", "system"))
+        msg, cat, turn = self.widget._entries[0]
+        self.assertEqual(msg, "Message 5")
+        self.assertEqual(cat, "system")
 
     def test_clear_removes_all(self):
         self.widget.add_entry("test", "damage")
@@ -38,7 +42,7 @@ class TestCombatLogWidget(BaseTestCase):
 
     def test_empty_log_shows_placeholder(self):
         text = self.widget._build_log_text()
-        self.assertIn("No entries", text.plain)
+        self.assertIn("Awaiting battle", text.plain)
 
     def test_narration_entries_present(self):
         self.widget.add_entry("A dark wind blows...", "narration")

--- a/emberblast/test/test_combat_log_widget.py
+++ b/emberblast/test/test_combat_log_widget.py
@@ -1,0 +1,46 @@
+"""Tests for the CombatLogWidget."""
+
+from emberblast.test.test import BaseTestCase
+from emberblast.tui.widgets.combat_log import CombatLogWidget
+
+
+class TestCombatLogWidget(BaseTestCase):
+    """Tests for the CombatLogWidget."""
+
+    def setUp(self):
+        self.widget = CombatLogWidget(max_entries=5)
+
+    def test_add_entry_stores_message(self):
+        self.widget.add_entry("Player attacked!", "damage")
+        self.assertEqual(len(self.widget._entries), 1)
+        self.assertEqual(self.widget._entries[0], ("Player attacked!", "damage"))
+
+    def test_max_entries_respected(self):
+        for i in range(10):
+            self.widget.add_entry(f"Message {i}", "system")
+        self.assertEqual(len(self.widget._entries), 5)
+        # Oldest entries should be gone, newest should remain
+        self.assertEqual(self.widget._entries[0], ("Message 5", "system"))
+
+    def test_clear_removes_all(self):
+        self.widget.add_entry("test", "damage")
+        self.widget.add_entry("test2", "heal")
+        self.widget.clear_log()
+        self.assertEqual(len(self.widget._entries), 0)
+
+    def test_build_text_contains_entries(self):
+        self.widget.add_entry("Fireball hits!", "damage")
+        self.widget.add_entry("Healed 20 HP", "heal")
+        text = self.widget._build_log_text()
+        plain = text.plain
+        self.assertIn("Fireball hits!", plain)
+        self.assertIn("Healed 20 HP", plain)
+
+    def test_empty_log_shows_placeholder(self):
+        text = self.widget._build_log_text()
+        self.assertIn("No entries", text.plain)
+
+    def test_narration_entries_present(self):
+        self.widget.add_entry("A dark wind blows...", "narration")
+        text = self.widget._build_log_text()
+        self.assertIn("A dark wind blows...", text.plain)

--- a/emberblast/test/test_combat_log_widget.py
+++ b/emberblast/test/test_combat_log_widget.py
@@ -7,44 +7,25 @@ from emberblast.tui.widgets.combat_log import CombatLogWidget
 class TestCombatLogWidget(BaseTestCase):
     """Tests for the CombatLogWidget."""
 
-    def setUp(self):
-        self.widget = CombatLogWidget(max_entries=5)
+    def test_widget_is_rich_log(self):
+        from textual.widgets import RichLog
 
-    def test_add_entry_stores_message(self):
-        self.widget.add_entry("Player attacked!", "damage")
-        self.assertEqual(len(self.widget._entries), 1)
-        msg, cat, turn = self.widget._entries[0]
-        self.assertEqual(msg, "Player attacked!")
-        self.assertEqual(cat, "damage")
+        widget = CombatLogWidget()
+        self.assertIsInstance(widget, RichLog)
 
-    def test_max_entries_respected(self):
-        for i in range(10):
-            self.widget.add_entry(f"Message {i}", "system")
-        self.assertEqual(len(self.widget._entries), 5)
-        # Oldest entries should be gone, newest should remain
-        msg, cat, turn = self.widget._entries[0]
-        self.assertEqual(msg, "Message 5")
-        self.assertEqual(cat, "system")
+    def test_set_turn_stores_value(self):
+        widget = CombatLogWidget()
+        widget.set_turn(3)
+        self.assertEqual(widget._current_turn, 3)
 
-    def test_clear_removes_all(self):
-        self.widget.add_entry("test", "damage")
-        self.widget.add_entry("test2", "heal")
-        self.widget.clear_log()
-        self.assertEqual(len(self.widget._entries), 0)
+    def test_has_add_entry(self):
+        widget = CombatLogWidget()
+        self.assertTrue(callable(getattr(widget, "add_entry", None)))
 
-    def test_build_text_contains_entries(self):
-        self.widget.add_entry("Fireball hits!", "damage")
-        self.widget.add_entry("Healed 20 HP", "heal")
-        text = self.widget._build_log_text()
-        plain = text.plain
-        self.assertIn("Fireball hits!", plain)
-        self.assertIn("Healed 20 HP", plain)
+    def test_has_clear_log(self):
+        widget = CombatLogWidget()
+        self.assertTrue(callable(getattr(widget, "clear_log", None)))
 
-    def test_empty_log_shows_placeholder(self):
-        text = self.widget._build_log_text()
-        self.assertIn("Awaiting battle", text.plain)
-
-    def test_narration_entries_present(self):
-        self.widget.add_entry("A dark wind blows...", "narration")
-        text = self.widget._build_log_text()
-        self.assertIn("A dark wind blows...", text.plain)
+    def test_auto_scroll_enabled(self):
+        widget = CombatLogWidget()
+        self.assertTrue(widget.auto_scroll)

--- a/emberblast/test/test_enemy_panel.py
+++ b/emberblast/test/test_enemy_panel.py
@@ -1,0 +1,55 @@
+"""Tests for the EnemyPanelWidget."""
+
+from unittest.mock import MagicMock
+
+from emberblast.test.test import BaseTestCase
+from emberblast.tui.widgets.enemy_panel import EnemyPanelWidget
+
+
+def _make_enemy(name="Goblin", job_name="Thief", level=3, life=50, health_points=50, alive=True, position=None):
+    e = MagicMock()
+    e.name = name
+    e.job.name = job_name
+    e.level = level
+    e.life = life
+    e.health_points = health_points
+    e.is_alive.return_value = alive
+    e.position = position or [1, 1]
+    return e
+
+
+class TestEnemyPanelWidget(BaseTestCase):
+    """Tests for the EnemyPanelWidget."""
+
+    def setUp(self):
+        self.widget = EnemyPanelWidget()
+
+    def test_header_appears(self):
+        text = self.widget._build_panel_text()
+        self.assertIn("ENEMIES", text.plain)
+
+    def test_alive_enemy_shows_name(self):
+        self.widget.update_enemies([_make_enemy(name="Orc")])
+        text = self.widget._build_panel_text()
+        self.assertIn("Orc", text.plain)
+
+    def test_alive_enemy_shows_hp(self):
+        self.widget.update_enemies([_make_enemy(life=30, health_points=50)])
+        text = self.widget._build_panel_text()
+        self.assertIn("30/50", text.plain)
+
+    def test_dead_enemy_shows_dead_label(self):
+        self.widget.update_enemies([_make_enemy(name="Skeleton", alive=False)])
+        text = self.widget._build_panel_text()
+        self.assertIn("DEAD", text.plain)
+
+    def test_empty_list_shows_placeholder(self):
+        self.widget.update_enemies([])
+        text = self.widget._build_panel_text()
+        self.assertIn("No enemies", text.plain)
+
+    def test_single_enemy_renders(self):
+        self.widget.update_enemies([_make_enemy(name="Dragon", job_name="Boss")])
+        text = self.widget._build_panel_text()
+        self.assertIn("Dragon", text.plain)
+        self.assertIn("Boss", text.plain)

--- a/emberblast/test/test_enemy_panel.py
+++ b/emberblast/test/test_enemy_panel.py
@@ -6,15 +6,34 @@ from emberblast.test.test import BaseTestCase
 from emberblast.tui.widgets.enemy_panel import EnemyPanelWidget
 
 
-def _make_enemy(name="Goblin", job_name="Thief", level=3, life=50, health_points=50, alive=True, position=None):
+def _make_enemy(
+    name="Goblin",
+    job_name="Thief",
+    level=3,
+    life=50,
+    health_points=50,
+    mana=10,
+    magic_points=20,
+    strength=8,
+    intelligence=5,
+    armour=3,
+    alive=True,
+    position=None,
+):
     e = MagicMock()
     e.name = name
     e.job.name = job_name
     e.level = level
     e.life = life
     e.health_points = health_points
+    e.mana = mana
+    e.magic_points = magic_points
+    e.strength = strength
+    e.intelligence = intelligence
+    e.armour = armour
     e.is_alive.return_value = alive
     e.position = position or [1, 1]
+    e.side_effects = []
     return e
 
 
@@ -38,6 +57,19 @@ class TestEnemyPanelWidget(BaseTestCase):
         text = self.widget._build_panel_text()
         self.assertIn("30/50", text.plain)
 
+    def test_alive_enemy_shows_mp(self):
+        self.widget.update_enemies([_make_enemy(mana=10, magic_points=20)])
+        text = self.widget._build_panel_text()
+        self.assertIn("10/20", text.plain)
+
+    def test_alive_enemy_shows_stats(self):
+        self.widget.update_enemies([_make_enemy(strength=12, intelligence=8, armour=5)])
+        text = self.widget._build_panel_text()
+        plain = text.plain
+        self.assertIn("STR:12", plain)
+        self.assertIn("INT:8", plain)
+        self.assertIn("ARM:5", plain)
+
     def test_dead_enemy_shows_dead_label(self):
         self.widget.update_enemies([_make_enemy(name="Skeleton", alive=False)])
         text = self.widget._build_panel_text()
@@ -47,6 +79,12 @@ class TestEnemyPanelWidget(BaseTestCase):
         self.widget.update_enemies([])
         text = self.widget._build_panel_text()
         self.assertIn("No enemies", text.plain)
+
+    def test_alive_count_shown(self):
+        enemies = [_make_enemy(name="Orc"), _make_enemy(name="Troll")]
+        self.widget.update_enemies(enemies)
+        text = self.widget._build_panel_text()
+        self.assertIn("2 alive", text.plain)
 
     def test_single_enemy_renders(self):
         self.widget.update_enemies([_make_enemy(name="Dragon", job_name="Boss")])

--- a/emberblast/test/test_enemy_panel.py
+++ b/emberblast/test/test_enemy_panel.py
@@ -66,9 +66,9 @@ class TestEnemyPanelWidget(BaseTestCase):
         self.widget.update_enemies([_make_enemy(strength=12, intelligence=8, armour=5)])
         text = self.widget._build_panel_text()
         plain = text.plain
-        self.assertIn("STR:12", plain)
-        self.assertIn("INT:8", plain)
-        self.assertIn("ARM:5", plain)
+        self.assertIn("STR 12", plain)
+        self.assertIn("INT 8", plain)
+        self.assertIn("ARM 5", plain)
 
     def test_dead_enemy_shows_dead_label(self):
         self.widget.update_enemies([_make_enemy(name="Skeleton", alive=False)])
@@ -91,3 +91,12 @@ class TestEnemyPanelWidget(BaseTestCase):
         text = self.widget._build_panel_text()
         self.assertIn("Dragon", text.plain)
         self.assertIn("Boss", text.plain)
+
+    def test_cycle_enemy_changes_selection(self):
+        enemies = [_make_enemy(name="Orc"), _make_enemy(name="Troll")]
+        self.widget.update_enemies(enemies)
+        self.assertEqual(self.widget._selected_idx, 0)
+        self.widget.cycle_enemy(1)
+        self.assertEqual(self.widget._selected_idx, 1)
+        self.widget.cycle_enemy(1)
+        self.assertEqual(self.widget._selected_idx, 0)  # wraps around

--- a/emberblast/test/test_map_widget.py
+++ b/emberblast/test/test_map_widget.py
@@ -71,5 +71,5 @@ class TestMapWidget(BaseTestCase):
     def test_update_map_stores_data(self):
         self.widget.update_map(self.matrix, self.size, self.players, "Gandalf", self.friendly_names)
         self.assertEqual(self.widget._matrix, self.matrix)
-        self.assertEqual(self.widget._size, self.size)
+        self.assertEqual(self.widget._grid_size, self.size)
         self.assertEqual(self.widget._active_player_name, "Gandalf")

--- a/emberblast/test/test_map_widget.py
+++ b/emberblast/test/test_map_widget.py
@@ -1,0 +1,75 @@
+"""Tests for the MapWidget."""
+
+from unittest.mock import MagicMock
+
+from emberblast.test.test import BaseTestCase
+from emberblast.tui.styles import get_player_token
+from emberblast.tui.widgets.map_grid import MapWidget
+
+
+def _make_player(name, job_name, position):
+    """Create a mock player for testing."""
+    p = MagicMock()
+    p.name = name
+    p.job.name = job_name
+    p.position = position
+    p.is_alive.return_value = True
+    return p
+
+
+class TestMapWidget(BaseTestCase):
+    """Tests for the MapWidget."""
+
+    def setUp(self):
+        self.widget = MapWidget()
+        # 3x3 matrix: plains(1), wall(2), water(3)
+        self.matrix = [
+            [1, 2, 3],
+            [4, 5, 1],
+            [1, 0, 2],
+        ]
+        self.size = 3
+        self.players = [
+            _make_player("Gandalf", "Wizard", [0, 0]),
+            _make_player("Sauron", "Warlock", [1, 1]),
+        ]
+        self.friendly_names = {"Gandalf"}
+
+    def test_grid_text_contains_column_headers(self):
+        self.widget.update_map(self.matrix, self.size, self.players, "Gandalf", self.friendly_names)
+        text = self.widget._build_grid_text()
+        plain = text.plain
+        self.assertIn("0", plain)
+        self.assertIn("1", plain)
+        self.assertIn("2", plain)
+
+    def test_grid_text_contains_row_labels(self):
+        self.widget.update_map(self.matrix, self.size, self.players, "Gandalf", self.friendly_names)
+        text = self.widget._build_grid_text()
+        plain = text.plain
+        self.assertIn("A", plain)
+        self.assertIn("B", plain)
+        self.assertIn("C", plain)
+
+    def test_player_tokens_appear(self):
+        self.widget.update_map(self.matrix, self.size, self.players, "Gandalf", self.friendly_names)
+        text = self.widget._build_grid_text()
+        plain = text.plain
+        token = get_player_token("Gandalf", "Wizard")
+        self.assertIn(token, plain)
+
+    def test_void_cells_render_as_spaces(self):
+        # matrix[2][1] == 0 => void
+        self.widget.update_map(self.matrix, self.size, [], "", set())
+        text = self.widget._build_grid_text()
+        plain = text.plain
+        # Row C should contain a space-like section for the void cell
+        lines = plain.split("\n")
+        row_c = [line for line in lines if line.strip().startswith("C")]
+        self.assertTrue(len(row_c) > 0)
+
+    def test_update_map_stores_data(self):
+        self.widget.update_map(self.matrix, self.size, self.players, "Gandalf", self.friendly_names)
+        self.assertEqual(self.widget._matrix, self.matrix)
+        self.assertEqual(self.widget._size, self.size)
+        self.assertEqual(self.widget._active_player_name, "Gandalf")

--- a/emberblast/test/test_player_hud_widget.py
+++ b/emberblast/test/test_player_hud_widget.py
@@ -1,0 +1,96 @@
+"""Tests for the PlayerHUDWidget."""
+
+from unittest.mock import MagicMock
+
+from emberblast.test.test import BaseTestCase
+from emberblast.tui.widgets.player_hud import PlayerHUDWidget
+
+
+def _make_player(
+    name="Hero",
+    job_name="Warrior",
+    race_name="Human",
+    level=5,
+    life=80,
+    health_points=100,
+    mana=30,
+    magic_points=50,
+    strength=15,
+    intelligence=10,
+    accuracy=12,
+    armour=8,
+    magic_resist=6,
+    move_speed=3,
+    will=7,
+):
+    p = MagicMock()
+    p.name = name
+    p.job.name = job_name
+    p.race.name = race_name
+    p.level = level
+    p.life = life
+    p.health_points = health_points
+    p.mana = mana
+    p.magic_points = magic_points
+    p.strength = strength
+    p.intelligence = intelligence
+    p.accuracy = accuracy
+    p.armour = armour
+    p.magic_resist = magic_resist
+    p.move_speed = move_speed
+    p.will = will
+    return p
+
+
+class TestPlayerHUDWidget(BaseTestCase):
+    """Tests for the PlayerHUDWidget."""
+
+    def setUp(self):
+        self.widget = PlayerHUDWidget()
+
+    def test_name_appears_in_hud(self):
+        player = _make_player(name="Gandalf")
+        self.widget.update_player(player)
+        text = self.widget._build_hud_text()
+        self.assertIn("Gandalf", text.plain)
+
+    def test_hp_values_appear(self):
+        player = _make_player(life=80, health_points=100)
+        self.widget.update_player(player)
+        text = self.widget._build_hud_text()
+        self.assertIn("80", text.plain)
+        self.assertIn("100", text.plain)
+
+    def test_mp_values_appear(self):
+        player = _make_player(mana=30, magic_points=50)
+        self.widget.update_player(player)
+        text = self.widget._build_hud_text()
+        self.assertIn("30", text.plain)
+        self.assertIn("50", text.plain)
+
+    def test_bar_color_green_above_50_percent(self):
+        player = _make_player(life=80, health_points=100)
+        self.widget.update_player(player)
+        text = self.widget._build_hud_text()
+        # Check that green color is used (spans contain green)
+        plain = text.plain
+        self.assertIn("80", plain)  # HP value present
+
+    def test_bar_color_changes_for_low_hp(self):
+        # Below 25%
+        player = _make_player(life=10, health_points=100)
+        self.widget.update_player(player)
+        text = self.widget._build_hud_text()
+        self.assertIn("10", text.plain)
+
+    def test_stats_line_appears(self):
+        player = _make_player(strength=15, intelligence=10)
+        self.widget.update_player(player)
+        text = self.widget._build_hud_text()
+        plain = text.plain
+        self.assertIn("STR", plain)
+        self.assertIn("INT", plain)
+
+    def test_no_player_shows_placeholder(self):
+        text = self.widget._build_hud_text()
+        self.assertIn("No player", text.plain)

--- a/emberblast/test/test_player_hud_widget.py
+++ b/emberblast/test/test_player_hud_widget.py
@@ -1,96 +1,21 @@
-"""Tests for the PlayerHUDWidget."""
+"""Tests for the PlayerHUDWidget (now CharacterBadgeWidget + EnemyPanelWidget).
 
-from unittest.mock import MagicMock
+This file is kept for backward compatibility — the actual widget tests
+are in test_character_badge.py and test_enemy_panel.py.
+"""
 
 from emberblast.test.test import BaseTestCase
-from emberblast.tui.widgets.player_hud import PlayerHUDWidget
+from emberblast.tui.widgets.character_badge import CharacterBadgeWidget
+from emberblast.tui.widgets.enemy_panel import EnemyPanelWidget
 
 
-def _make_player(
-    name="Hero",
-    job_name="Warrior",
-    race_name="Human",
-    level=5,
-    life=80,
-    health_points=100,
-    mana=30,
-    magic_points=50,
-    strength=15,
-    intelligence=10,
-    accuracy=12,
-    armour=8,
-    magic_resist=6,
-    move_speed=3,
-    will=7,
-):
-    p = MagicMock()
-    p.name = name
-    p.job.name = job_name
-    p.race.name = race_name
-    p.level = level
-    p.life = life
-    p.health_points = health_points
-    p.mana = mana
-    p.magic_points = magic_points
-    p.strength = strength
-    p.intelligence = intelligence
-    p.accuracy = accuracy
-    p.armour = armour
-    p.magic_resist = magic_resist
-    p.move_speed = move_speed
-    p.will = will
-    return p
+class TestPlayerHUDWidgetMigration(BaseTestCase):
+    """Verify the old PlayerHUDWidget was replaced by new widgets."""
 
+    def test_character_badge_exists(self):
+        widget = CharacterBadgeWidget()
+        self.assertTrue(callable(getattr(widget, "update_player", None)))
 
-class TestPlayerHUDWidget(BaseTestCase):
-    """Tests for the PlayerHUDWidget."""
-
-    def setUp(self):
-        self.widget = PlayerHUDWidget()
-
-    def test_name_appears_in_hud(self):
-        player = _make_player(name="Gandalf")
-        self.widget.update_player(player)
-        text = self.widget._build_hud_text()
-        self.assertIn("Gandalf", text.plain)
-
-    def test_hp_values_appear(self):
-        player = _make_player(life=80, health_points=100)
-        self.widget.update_player(player)
-        text = self.widget._build_hud_text()
-        self.assertIn("80", text.plain)
-        self.assertIn("100", text.plain)
-
-    def test_mp_values_appear(self):
-        player = _make_player(mana=30, magic_points=50)
-        self.widget.update_player(player)
-        text = self.widget._build_hud_text()
-        self.assertIn("30", text.plain)
-        self.assertIn("50", text.plain)
-
-    def test_bar_color_green_above_50_percent(self):
-        player = _make_player(life=80, health_points=100)
-        self.widget.update_player(player)
-        text = self.widget._build_hud_text()
-        # Check that green color is used (spans contain green)
-        plain = text.plain
-        self.assertIn("80", plain)  # HP value present
-
-    def test_bar_color_changes_for_low_hp(self):
-        # Below 25%
-        player = _make_player(life=10, health_points=100)
-        self.widget.update_player(player)
-        text = self.widget._build_hud_text()
-        self.assertIn("10", text.plain)
-
-    def test_stats_line_appears(self):
-        player = _make_player(strength=15, intelligence=10)
-        self.widget.update_player(player)
-        text = self.widget._build_hud_text()
-        plain = text.plain
-        self.assertIn("STR", plain)
-        self.assertIn("INT", plain)
-
-    def test_no_player_shows_placeholder(self):
-        text = self.widget._build_hud_text()
-        self.assertIn("No player", text.plain)
+    def test_enemy_panel_exists(self):
+        widget = EnemyPanelWidget()
+        self.assertTrue(callable(getattr(widget, "update_enemies", None)))

--- a/emberblast/test/test_questions_cmd.py
+++ b/emberblast/test/test_questions_cmd.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from emberblast.communicator import communicator_injector
 from emberblast.interface import IEquipmentItem, IItem, IPlayer
 
@@ -22,50 +24,52 @@ class TestModuleQuestions(CommunicatorTestCase):
         pass
 
     def test_ask_check_action(self) -> None:
-        result = self.communicator.questioner.ask_check_action()
+        result = asyncio.run(self.communicator.questioner.ask_check_action())
         assert isinstance(result, str)
 
     def test_ask_actions_questions(self) -> None:
-        result = self.communicator.questioner.ask_actions_questions(
-            ["move", "attack", "skill", "defend", "hide", "search", "item", "equip", "drop", "check", "pass"]
+        result = asyncio.run(
+            self.communicator.questioner.ask_actions_questions(
+                ["move", "attack", "skill", "defend", "hide", "search", "item", "equip", "drop", "check", "pass"]
+            )
         )
         assert isinstance(result, str)
 
     def test_select_item(self):
         items = [self.mock_equipment_item, self.mock_healing_item, self.mock_recovery_item]
-        result = self.communicator.questioner.select_item(items)
+        result = asyncio.run(self.communicator.questioner.select_item(items))
         assert isinstance(result, IItem)
 
     def test_ask_enemy_to_check(self) -> None:
-        result = self.questioning_system.enemies_questioner.ask_enemy_to_check([self.mock_player])
+        result = asyncio.run(self.questioning_system.enemies_questioner.ask_enemy_to_check([self.mock_player]))
         assert isinstance(result, IPlayer)
 
     def test_confirm_item_selection(self) -> None:
-        result = self.communicator.questioner.confirm_item_selection()
+        result = asyncio.run(self.communicator.questioner.confirm_item_selection())
         assert isinstance(result, bool)
 
     def test_confirm_use_item_on_you(self) -> None:
-        result = self.communicator.questioner.confirm_use_item_on_you()
+        result = asyncio.run(self.communicator.questioner.confirm_use_item_on_you())
         assert isinstance(result, bool)
 
     def test_display_equipment_choices(self) -> None:
         self.mock_player.bag.add_item(self.mock_equipment_item)
-        result = self.communicator.questioner.display_equipment_choices(self.mock_player)
+        result = asyncio.run(self.communicator.questioner.display_equipment_choices(self.mock_player))
         assert isinstance(result, IEquipmentItem)
 
     def test_ask_where_to_move(self) -> None:
         possibilities = self.mock_map.graph.get_available_nodes_in_range("A0", 5)
-        result = self.questioning_system.movement_questioner.ask_where_to_move(possibilities)
+        result = asyncio.run(self.questioning_system.movement_questioner.ask_where_to_move(possibilities))
         assert isinstance(result, str)
 
     def test_perform_game_create_questions(self) -> None:
-        result = self.questioning_system.new_game_questioner.perform_game_create_questions()
+        result = asyncio.run(self.questioning_system.new_game_questioner.perform_game_create_questions())
         assert isinstance(result, dict)
 
     def test_perform_first_question(self) -> None:
-        result = self.questioning_system.new_game_questioner.perform_first_question()
+        result = asyncio.run(self.questioning_system.new_game_questioner.perform_first_question())
         assert isinstance(result, str)
 
     def test_ask_attributes_to_improve(self) -> None:
-        result = self.questioning_system.level_up_questioner.ask_attributes_to_improve()
+        result = asyncio.run(self.questioning_system.level_up_questioner.ask_attributes_to_improve())
         assert isinstance(result, list)

--- a/emberblast/test/test_setup_screen.py
+++ b/emberblast/test/test_setup_screen.py
@@ -1,0 +1,38 @@
+"""Tests for SetupScreen."""
+
+from emberblast.test.test import BaseTestCase
+from emberblast.tui.screens.setup import SetupScreen
+
+
+class TestSetupScreenStructure(BaseTestCase):
+    """Verify SetupScreen has expected structure."""
+
+    def test_has_compose(self):
+        self.assertHasAttr(SetupScreen, "compose")
+
+    def test_has_set_questioner(self):
+        self.assertHasAttr(SetupScreen, "set_questioner")
+
+    def test_has_show_list(self):
+        self.assertHasAttr(SetupScreen, "show_list")
+
+    def test_has_show_input(self):
+        self.assertHasAttr(SetupScreen, "show_input")
+
+    def test_has_on_key(self):
+        self.assertHasAttr(SetupScreen, "on_key")
+
+    def test_has_on_input_submitted(self):
+        self.assertHasAttr(SetupScreen, "on_input_submitted")
+
+    def test_stores_question_type(self):
+        screen = SetupScreen(question_type="game_create")
+        self.assertEqual(screen._question_type, "game_create")
+
+    def test_default_mode_is_idle(self):
+        screen = SetupScreen()
+        self.assertEqual(screen._mode, "idle")
+
+    def test_default_question_type_is_empty(self):
+        screen = SetupScreen()
+        self.assertEqual(screen._question_type, "")

--- a/emberblast/test/test_textual_questioner.py
+++ b/emberblast/test/test_textual_questioner.py
@@ -1,11 +1,14 @@
 import asyncio
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 
 class TestTextualQuestioner(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.app = MagicMock()
+        # Make push_screen and pop_screen async-compatible for multi-step methods
+        self.app.push_screen = AsyncMock()
+        self.app.pop_screen = MagicMock()
         from emberblast.tui.questioner import TextualQuestioner
 
         self.questioner = TextualQuestioner(self.app)
@@ -44,9 +47,7 @@ class TestTextualQuestioner(unittest.IsolatedAsyncioTestCase):
         asyncio.create_task(resolver())
         result = await self.questioner.ask_actions_questions(actions_available=["attack", "move"])
         self.assertEqual(result, "attack")
-        self.app.handle_question.assert_called_once_with(
-            "ask_actions_questions", actions_available=["attack", "move"]
-        )
+        self.app.handle_question.assert_called_once_with("ask_actions_questions", actions_available=["attack", "move"])
 
     async def test_ask_enemy_to_check(self):
         enemies = [MagicMock(), MagicMock()]
@@ -70,9 +71,7 @@ class TestTextualQuestioner(unittest.IsolatedAsyncioTestCase):
         asyncio.create_task(resolver())
         result = await self.questioner.ask_enemy_to_attack(enemies=enemies, skill_type="melee")
         self.assertEqual(result, enemies[0])
-        self.app.handle_question.assert_called_once_with(
-            "ask_enemy_to_attack", enemies=enemies, skill_type="melee"
-        )
+        self.app.handle_question.assert_called_once_with("ask_enemy_to_attack", enemies=enemies, skill_type="melee")
 
     async def test_select_item(self):
         items = [MagicMock()]
@@ -150,16 +149,24 @@ class TestTextualQuestioner(unittest.IsolatedAsyncioTestCase):
         self.app.handle_question.assert_called_once_with("perform_first_question")
 
     async def test_perform_game_create_questions(self):
-        config = {"map_size": 10, "bots": 3}
+        """Multi-step: resolves 4 sub-questions into a dict."""
+        answers = ["Deathmatch", "Millstone Plains", "1", "4"]
+        call_count = 0
 
         async def resolver():
-            await asyncio.sleep(0.01)
-            self.questioner.resolve(config)
+            nonlocal call_count
+            for answer in answers:
+                await asyncio.sleep(0.1)
+                self.questioner.resolve(answer)
+                call_count += 1
 
         asyncio.create_task(resolver())
         result = await self.questioner.perform_game_create_questions()
-        self.assertEqual(result, config)
-        self.app.handle_question.assert_called_once_with("perform_game_create_questions")
+        self.assertEqual(result["game"], "Deathmatch")
+        self.assertEqual(result["map"], "Millstone Plains")
+        self.assertEqual(result["controlled_players_number"], "1")
+        self.assertEqual(result["bots_number"], "4")
+        self.assertEqual(call_count, 4)
 
     async def test_select_skill(self):
         skills = [MagicMock()]
@@ -174,32 +181,43 @@ class TestTextualQuestioner(unittest.IsolatedAsyncioTestCase):
         self.app.handle_question.assert_called_once_with("select_skill", available_skills=skills)
 
     async def test_get_saved_game(self):
+        """Uses _ask_setup_list to show saved games."""
         from pathlib import Path
 
         files = [{"path": Path("/save1"), "name": "Save 1"}]
 
         async def resolver():
-            await asyncio.sleep(0.01)
+            await asyncio.sleep(0.1)
             self.questioner.resolve(Path("/save1"))
 
         asyncio.create_task(resolver())
         result = await self.questioner.get_saved_game(normalized_files=files)
         self.assertEqual(result, Path("/save1"))
-        self.app.handle_question.assert_called_once_with("get_saved_game", normalized_files=files)
+        # Should have pushed and popped a setup screen
+        self.app.push_screen.assert_called_once()
+        self.app.pop_screen.assert_called_once()
 
-    async def test_perform_character_creation_questions(self):
-        char = {"name": "Hero", "race": "Elf", "job": "Mage"}
+    @patch("emberblast.conf.get_configuration")
+    async def test_perform_character_creation_questions(self, mock_get_config):
+        """Multi-step: resolves name, race, job into a dict."""
+        mock_get_config.return_value = {"Elf": {}, "Orc": {}, "Human": {}}
+
+        answers = ["Hero", "Elf", "Knight"]
+        call_count = 0
 
         async def resolver():
-            await asyncio.sleep(0.01)
-            self.questioner.resolve(char)
+            nonlocal call_count
+            for answer in answers:
+                await asyncio.sleep(0.1)
+                self.questioner.resolve(answer)
+                call_count += 1
 
         asyncio.create_task(resolver())
         result = await self.questioner.perform_character_creation_questions(existing_names=["Bot1"])
-        self.assertEqual(result, char)
-        self.app.handle_question.assert_called_once_with(
-            "perform_character_creation_questions", existing_names=["Bot1"]
-        )
+        self.assertEqual(result["nickname"], "Hero")
+        self.assertEqual(result["race"], "Elf")
+        self.assertEqual(result["job"], "Knight")
+        self.assertEqual(call_count, 3)
 
     async def test_multiple_sequential_questions(self):
         """Verify questioner can handle multiple questions in sequence."""

--- a/emberblast/test/test_textual_questioner.py
+++ b/emberblast/test/test_textual_questioner.py
@@ -1,0 +1,221 @@
+import asyncio
+import unittest
+from unittest.mock import MagicMock
+
+
+class TestTextualQuestioner(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.app = MagicMock()
+        from emberblast.tui.questioner import TextualQuestioner
+
+        self.questioner = TextualQuestioner(self.app)
+
+    async def test_resolve_unblocks_wait_for_response(self):
+        async def resolver():
+            await asyncio.sleep(0.01)
+            self.questioner.resolve("some_value")
+
+        asyncio.create_task(resolver())
+        result = await self.questioner._wait_for_response()
+        self.assertEqual(result, "some_value")
+
+    async def test_response_cleared_after_wait(self):
+        self.questioner.resolve("first")
+        result = await self.questioner._wait_for_response()
+        self.assertEqual(result, "first")
+        self.assertIsNone(self.questioner._response)
+        self.assertFalse(self.questioner._response_event.is_set())
+
+    async def test_ask_check_action(self):
+        async def resolver():
+            await asyncio.sleep(0.01)
+            self.questioner.resolve("stats")
+
+        asyncio.create_task(resolver())
+        result = await self.questioner.ask_check_action(show_items=True)
+        self.assertEqual(result, "stats")
+        self.app.handle_question.assert_called_once_with("ask_check_action", show_items=True)
+
+    async def test_ask_actions_questions(self):
+        async def resolver():
+            await asyncio.sleep(0.01)
+            self.questioner.resolve("attack")
+
+        asyncio.create_task(resolver())
+        result = await self.questioner.ask_actions_questions(actions_available=["attack", "move"])
+        self.assertEqual(result, "attack")
+        self.app.handle_question.assert_called_once_with(
+            "ask_actions_questions", actions_available=["attack", "move"]
+        )
+
+    async def test_ask_enemy_to_check(self):
+        enemies = [MagicMock(), MagicMock()]
+
+        async def resolver():
+            await asyncio.sleep(0.01)
+            self.questioner.resolve(enemies[0])
+
+        asyncio.create_task(resolver())
+        result = await self.questioner.ask_enemy_to_check(enemies=enemies)
+        self.assertEqual(result, enemies[0])
+        self.app.handle_question.assert_called_once_with("ask_enemy_to_check", enemies=enemies)
+
+    async def test_ask_enemy_to_attack(self):
+        enemies = [MagicMock()]
+
+        async def resolver():
+            await asyncio.sleep(0.01)
+            self.questioner.resolve(enemies[0])
+
+        asyncio.create_task(resolver())
+        result = await self.questioner.ask_enemy_to_attack(enemies=enemies, skill_type="melee")
+        self.assertEqual(result, enemies[0])
+        self.app.handle_question.assert_called_once_with(
+            "ask_enemy_to_attack", enemies=enemies, skill_type="melee"
+        )
+
+    async def test_select_item(self):
+        items = [MagicMock()]
+
+        async def resolver():
+            await asyncio.sleep(0.01)
+            self.questioner.resolve(items[0])
+
+        asyncio.create_task(resolver())
+        result = await self.questioner.select_item(items=items)
+        self.assertEqual(result, items[0])
+        self.app.handle_question.assert_called_once_with("select_item", items=items)
+
+    async def test_confirm_item_selection(self):
+        async def resolver():
+            await asyncio.sleep(0.01)
+            self.questioner.resolve(True)
+
+        asyncio.create_task(resolver())
+        result = await self.questioner.confirm_item_selection()
+        self.assertTrue(result)
+        self.app.handle_question.assert_called_once_with("confirm_item_selection")
+
+    async def test_confirm_use_item_on_you(self):
+        async def resolver():
+            await asyncio.sleep(0.01)
+            self.questioner.resolve(False)
+
+        asyncio.create_task(resolver())
+        result = await self.questioner.confirm_use_item_on_you()
+        self.assertFalse(result)
+        self.app.handle_question.assert_called_once_with("confirm_use_item_on_you")
+
+    async def test_display_equipment_choices(self):
+        player = MagicMock()
+        equipment = MagicMock()
+
+        async def resolver():
+            await asyncio.sleep(0.01)
+            self.questioner.resolve(equipment)
+
+        asyncio.create_task(resolver())
+        result = await self.questioner.display_equipment_choices(player=player)
+        self.assertEqual(result, equipment)
+        self.app.handle_question.assert_called_once_with("display_equipment_choices", player=player)
+
+    async def test_ask_attributes_to_improve(self):
+        async def resolver():
+            await asyncio.sleep(0.01)
+            self.questioner.resolve(["strength", "accuracy"])
+
+        asyncio.create_task(resolver())
+        result = await self.questioner.ask_attributes_to_improve()
+        self.assertEqual(result, ["strength", "accuracy"])
+        self.app.handle_question.assert_called_once_with("ask_attributes_to_improve")
+
+    async def test_ask_where_to_move(self):
+        async def resolver():
+            await asyncio.sleep(0.01)
+            self.questioner.resolve("B1")
+
+        asyncio.create_task(resolver())
+        result = await self.questioner.ask_where_to_move(possibilities=["A1", "B1"])
+        self.assertEqual(result, "B1")
+        self.app.handle_question.assert_called_once_with("ask_where_to_move", possibilities=["A1", "B1"])
+
+    async def test_perform_first_question(self):
+        async def resolver():
+            await asyncio.sleep(0.01)
+            self.questioner.resolve("new_game")
+
+        asyncio.create_task(resolver())
+        result = await self.questioner.perform_first_question()
+        self.assertEqual(result, "new_game")
+        self.app.handle_question.assert_called_once_with("perform_first_question")
+
+    async def test_perform_game_create_questions(self):
+        config = {"map_size": 10, "bots": 3}
+
+        async def resolver():
+            await asyncio.sleep(0.01)
+            self.questioner.resolve(config)
+
+        asyncio.create_task(resolver())
+        result = await self.questioner.perform_game_create_questions()
+        self.assertEqual(result, config)
+        self.app.handle_question.assert_called_once_with("perform_game_create_questions")
+
+    async def test_select_skill(self):
+        skills = [MagicMock()]
+
+        async def resolver():
+            await asyncio.sleep(0.01)
+            self.questioner.resolve(skills[0])
+
+        asyncio.create_task(resolver())
+        result = await self.questioner.select_skill(available_skills=skills)
+        self.assertEqual(result, skills[0])
+        self.app.handle_question.assert_called_once_with("select_skill", available_skills=skills)
+
+    async def test_get_saved_game(self):
+        from pathlib import Path
+
+        files = [{"path": Path("/save1"), "name": "Save 1"}]
+
+        async def resolver():
+            await asyncio.sleep(0.01)
+            self.questioner.resolve(Path("/save1"))
+
+        asyncio.create_task(resolver())
+        result = await self.questioner.get_saved_game(normalized_files=files)
+        self.assertEqual(result, Path("/save1"))
+        self.app.handle_question.assert_called_once_with("get_saved_game", normalized_files=files)
+
+    async def test_perform_character_creation_questions(self):
+        char = {"name": "Hero", "race": "Elf", "job": "Mage"}
+
+        async def resolver():
+            await asyncio.sleep(0.01)
+            self.questioner.resolve(char)
+
+        asyncio.create_task(resolver())
+        result = await self.questioner.perform_character_creation_questions(existing_names=["Bot1"])
+        self.assertEqual(result, char)
+        self.app.handle_question.assert_called_once_with(
+            "perform_character_creation_questions", existing_names=["Bot1"]
+        )
+
+    async def test_multiple_sequential_questions(self):
+        """Verify questioner can handle multiple questions in sequence."""
+
+        async def resolver1():
+            await asyncio.sleep(0.01)
+            self.questioner.resolve("attack")
+
+        asyncio.create_task(resolver1())
+        result1 = await self.questioner.ask_actions_questions(actions_available=["attack"])
+        self.assertEqual(result1, "attack")
+
+        async def resolver2():
+            await asyncio.sleep(0.01)
+            self.questioner.resolve("B1")
+
+        asyncio.create_task(resolver2())
+        result2 = await self.questioner.ask_where_to_move(possibilities=["B1"])
+        self.assertEqual(result2, "B1")

--- a/emberblast/test/test_textual_renderer.py
+++ b/emberblast/test/test_textual_renderer.py
@@ -1,0 +1,348 @@
+from unittest.mock import MagicMock
+
+from emberblast.events import (
+    AreaDamageEvent,
+    CheckItemEvent,
+    DamageEvent,
+    DeathEvent,
+    DiceRollEvent,
+    EnemyStatusEvent,
+    EventAction,
+    GreetingsEvent,
+    HealEvent,
+    ItemEvent,
+    ItemFoundEvent,
+    IteratedSideEffectEvent,
+    LevelUpEvent,
+    LineSeparatorEvent,
+    LowManaEvent,
+    MapInfoEvent,
+    MissedAttackEvent,
+    MoveEvent,
+    MovingPossibilitiesEvent,
+    NarrationEvent,
+    NewCharacterEvent,
+    NoFoesEvent,
+    PlayerFailStoleItemEvent,
+    PlayerStatsEvent,
+    PlayerStoleItemEvent,
+    PlayerTurnEvent,
+    SideEffectEndedEvent,
+    SideEffectEvent,
+    SkillEvent,
+    SpentManaEvent,
+    TrapActivatedEvent,
+    TurnStartEvent,
+    UseItemEvent,
+    VictoryEvent,
+    XPEarnedEvent,
+)
+from emberblast.test.test import BaseTestCase
+
+
+class TestTextualRenderer(BaseTestCase):
+    def setUp(self):
+        self.app = MagicMock()
+        from emberblast.tui.renderer import TextualRenderer
+
+        self.renderer = TextualRenderer(self.app)
+
+    def test_render_greetings_posts_combat_log(self):
+        self.renderer.render(GreetingsEvent())
+        self.app.post_combat_log.assert_called_once()
+        args = self.app.post_combat_log.call_args
+        self.assertIn("EMBERBLAST", args[0][0])
+
+    def test_render_turn_start_sets_turn_and_posts_log(self):
+        self.renderer.render(TurnStartEvent(turn=3))
+        self.app.set_turn.assert_called_once_with(3)
+        self.app.post_combat_log.assert_called_once()
+
+    def test_render_player_turn_sets_active_player(self):
+        self.renderer.render(PlayerTurnEvent(player_name="Hero"))
+        self.app.set_active_player.assert_called_once_with("Hero")
+        self.app.post_combat_log.assert_called_once()
+
+    def test_render_line_separator_posts_log(self):
+        self.renderer.render(LineSeparatorEvent())
+        self.app.post_combat_log.assert_called_once()
+
+    def test_render_move_with_positions(self):
+        self.renderer.render(MoveEvent(player_name="Hero", from_position="A0", to_position="B1"))
+        self.app.post_combat_log.assert_called_once()
+        msg = self.app.post_combat_log.call_args[0][0]
+        self.assertIn("Hero", msg)
+        self.assertIn("A0", msg)
+        self.assertIn("B1", msg)
+
+    def test_render_move_without_positions(self):
+        self.renderer.render(MoveEvent(player_name="Hero"))
+        self.app.post_combat_log.assert_called_once()
+        msg = self.app.post_combat_log.call_args[0][0]
+        self.assertIn("Hero", msg)
+
+    def test_render_damage(self):
+        self.renderer.render(
+            DamageEvent(attacker_name="Atk", target_name="Def", damage=50, target_alive=True, target_life=100)
+        )
+        self.app.post_combat_log.assert_called()
+        self.app.refresh_huds.assert_called()
+
+    def test_render_damage_target_dead(self):
+        self.renderer.render(
+            DamageEvent(attacker_name="Atk", target_name="Def", damage=50, target_alive=False, target_life=0)
+        )
+        self.app.post_combat_log.assert_called()
+
+    def test_render_heal(self):
+        self.renderer.render(HealEvent(healer_name="Heal", target_name="Hurt", amount=30, target_life=80))
+        self.app.post_combat_log.assert_called()
+        self.app.refresh_huds.assert_called()
+
+    def test_render_spent_mana(self):
+        self.renderer.render(SpentManaEvent(player_name="Mage", amount=20, skill_name="Fireball"))
+        self.app.post_combat_log.assert_called_once()
+        self.app.refresh_huds.assert_called()
+
+    def test_render_use_item(self):
+        self.renderer.render(UseItemEvent(player_name="Hero", item_name="Potion", target_name="Hero"))
+        self.app.post_combat_log.assert_called_once()
+
+    def test_render_dice_roll(self):
+        self.renderer.render(DiceRollEvent(player_name="Hero", result=6, kind="attack", is_critical=False))
+        self.app.post_combat_log.assert_called()
+
+    def test_render_dice_roll_critical(self):
+        self.renderer.render(DiceRollEvent(player_name="Hero", result=20, kind="attack", is_critical=True))
+        calls = self.app.post_combat_log.call_args_list
+        self.assertTrue(len(calls) >= 2)
+
+    def test_render_narration(self):
+        self.renderer.render(NarrationEvent(player_name="Hero", text="I shall prevail!"))
+        self.app.post_combat_log.assert_called_once()
+
+    def test_render_death(self):
+        self.renderer.render(DeathEvent(player_name="Villain"))
+        self.app.post_combat_log.assert_called_once()
+        self.app.refresh_huds.assert_called()
+
+    def test_render_victory_shows_game_over(self):
+        self.renderer.render(VictoryEvent(player_name="Hero"))
+        self.app.show_game_over.assert_called_once_with("Hero")
+
+    def test_render_side_effect_debuff_constant(self):
+        self.renderer.render(
+            SideEffectEvent(player_name="Hero", effect_name="Poison", effect_type="debuff", occurrence="constant")
+        )
+        self.app.post_combat_log.assert_called_once()
+        self.assertIn("debuffed", self.app.post_combat_log.call_args[0][0])
+
+    def test_render_side_effect_debuff_iterated(self):
+        self.renderer.render(
+            SideEffectEvent(player_name="Hero", effect_name="Burn", effect_type="debuff", occurrence="iterated")
+        )
+        self.assertIn("inflicted", self.app.post_combat_log.call_args[0][0])
+
+    def test_render_side_effect_buff(self):
+        self.renderer.render(
+            SideEffectEvent(player_name="Hero", effect_name="Shield", effect_type="buff", occurrence="constant")
+        )
+        self.assertIn("buffed", self.app.post_combat_log.call_args[0][0])
+
+    def test_render_side_effect_ended(self):
+        self.renderer.render(SideEffectEndedEvent(player_name="Hero", effect_name="Poison"))
+        self.app.post_combat_log.assert_called_once()
+
+    def test_render_iterated_side_effect(self):
+        self.renderer.render(
+            IteratedSideEffectEvent(
+                player_name="Hero",
+                effect_name="Burn",
+                effect_type="debuff",
+                attribute="health_points",
+                value=5,
+                turns_remaining=3,
+            )
+        )
+        self.app.post_combat_log.assert_called_once()
+        msg = self.app.post_combat_log.call_args[0][0]
+        self.assertIn("life", msg)
+
+    def test_render_item_found_success(self):
+        self.renderer.render(ItemFoundEvent(player_name="Hero", found=True, item_name="Sword", item_tier="gold"))
+        self.app.post_combat_log.assert_called_once()
+
+    def test_render_item_found_failure(self):
+        self.renderer.render(ItemFoundEvent(player_name="Hero", found=False))
+        self.app.post_combat_log.assert_called_once()
+
+    def test_render_level_up(self):
+        self.renderer.render(LevelUpEvent(player_name="Hero", new_level=5))
+        self.app.post_combat_log.assert_called_once()
+        self.app.refresh_huds.assert_called()
+
+    def test_render_xp_earned_with_kill(self):
+        self.renderer.render(XPEarnedEvent(player_name="Hero", xp=100, kill_target="Villain"))
+        msg = self.app.post_combat_log.call_args[0][0]
+        self.assertIn("Villain", msg)
+
+    def test_render_xp_earned_no_kill(self):
+        self.renderer.render(XPEarnedEvent(player_name="Hero", xp=50))
+        self.app.post_combat_log.assert_called_once()
+
+    def test_render_event_action(self):
+        self.renderer.render(EventAction(event="attack"))
+        self.app.post_combat_log.assert_called_once()
+
+    def test_render_low_mana(self):
+        self.renderer.render(LowManaEvent(player_name="Mage", mana=5))
+        self.app.post_combat_log.assert_called_once()
+
+    def test_render_missed_attack(self):
+        self.renderer.render(MissedAttackEvent(attacker_name="Hero", target_name="Foe"))
+        self.app.post_combat_log.assert_called_once()
+
+    def test_render_trap_activated(self):
+        self.renderer.render(TrapActivatedEvent(player_name="Hero", side_effect_names=["Poison", "Burn"]))
+        calls = self.app.post_combat_log.call_args_list
+        self.assertTrue(len(calls) >= 2)
+
+    def test_render_no_foes(self):
+        self.renderer.render(NoFoesEvent(message="No enemies nearby"))
+        self.app.post_combat_log.assert_called_once()
+
+    def test_render_area_damage(self):
+        player = MagicMock()
+        player.name = "Target"
+        player.job.get_name.return_value = "Warrior"
+        player.position = "A0"
+        player.life = 100
+        self.renderer.render(AreaDamageEvent(skill_name="Blizzard", skill_kind="magic", affected_players=[player]))
+        self.app.post_combat_log.assert_called()
+
+    def test_render_player_stole_item(self):
+        self.renderer.render(
+            PlayerStoleItemEvent(player_name="Thief", foe_name="Victim", item_name="Ring", tier="silver")
+        )
+        self.app.post_combat_log.assert_called_once()
+
+    def test_render_player_fail_stole_item(self):
+        self.renderer.render(PlayerFailStoleItemEvent(player_name="Thief", foe_name="Victim"))
+        self.app.post_combat_log.assert_called_once()
+
+    def test_render_new_character(self):
+        self.renderer.render(NewCharacterEvent(number=1))
+        self.app.post_combat_log.assert_called_once()
+
+    def test_render_map_info_calls_update_map(self):
+        self.renderer.render(
+            MapInfoEvent(current_player="p", enemies=["e"], matrix=[[1]], size=1)
+        )
+        self.app.update_map_from_event.assert_called_once_with("p", ["e"], [[1]], 1)
+
+    def test_render_moving_possibilities(self):
+        self.renderer.render(
+            MovingPossibilitiesEvent(player_position="A0", possibilities=["A1", "B0"], matrix=[[1]], size=1)
+        )
+        self.app.show_move_highlights.assert_called_once_with("A0", ["A1", "B0"], [[1]], 1)
+
+    def test_render_player_stats(self):
+        player = MagicMock()
+        player.name = "Hero"
+        player.level = 5
+        player.life = 100
+        player.health_points = 120
+        player.mana = 50
+        player.magic_points = 60
+        player.strength = 10
+        player.intelligence = 8
+        player.accuracy = 7
+        player.armour = 5
+        player.magic_resist = 4
+        player.move_speed = 3
+        player.will = 6
+        self.renderer.render(PlayerStatsEvent(player=player))
+        self.app.post_combat_log.assert_called_once()
+
+    def test_render_enemy_status(self):
+        enemy = MagicMock()
+        enemy.name = "Foe"
+        enemy.job.get_name.return_value = "Mage"
+        enemy.position = "B2"
+        enemy.level = 3
+        enemy.life = 80
+        enemy.health_points = 100
+        enemy.mana = 40
+        enemy.magic_points = 50
+        enemy.strength = 8
+        enemy.intelligence = 12
+        enemy.accuracy = 6
+        enemy.armour = 3
+        enemy.magic_resist = 7
+        enemy.move_speed = 4
+        enemy.will = 5
+        self.renderer.render(EnemyStatusEvent(enemy=enemy))
+        self.app.post_combat_log.assert_called_once()
+
+    def test_render_check_item(self):
+        item = MagicMock()
+        item.name = "Sword"
+        item.tier = "gold"
+        item.description = "A sharp sword"
+        item.weight = 2.5
+        self.renderer.render(CheckItemEvent(item=item))
+        self.app.post_combat_log.assert_called_once()
+
+    def test_render_skill_event(self):
+        self.renderer.render(SkillEvent(caster_name="Mage", skill_name="Fireball", mana_cost=20))
+        self.app.post_combat_log.assert_called_once()
+
+    def test_render_item_event(self):
+        self.renderer.render(ItemEvent(player_name="Hero", item_name="Potion", target_name="Hero"))
+        self.app.post_combat_log.assert_called_once()
+
+    def test_unknown_event_does_not_crash(self):
+        from emberblast.events.events import GameEvent
+
+        self.renderer.render(GameEvent())  # base event, not in dispatch
+
+    def test_all_event_types_in_dispatch(self):
+        """Verify that every concrete event type has a handler."""
+        expected_types = {
+            GreetingsEvent,
+            TurnStartEvent,
+            PlayerTurnEvent,
+            LineSeparatorEvent,
+            MoveEvent,
+            DamageEvent,
+            HealEvent,
+            SkillEvent,
+            SpentManaEvent,
+            ItemEvent,
+            UseItemEvent,
+            DiceRollEvent,
+            NarrationEvent,
+            DeathEvent,
+            VictoryEvent,
+            SideEffectEvent,
+            SideEffectEndedEvent,
+            IteratedSideEffectEvent,
+            ItemFoundEvent,
+            LevelUpEvent,
+            XPEarnedEvent,
+            EventAction,
+            LowManaEvent,
+            MissedAttackEvent,
+            TrapActivatedEvent,
+            NoFoesEvent,
+            AreaDamageEvent,
+            PlayerStoleItemEvent,
+            PlayerFailStoleItemEvent,
+            NewCharacterEvent,
+            MapInfoEvent,
+            MovingPossibilitiesEvent,
+            PlayerStatsEvent,
+            EnemyStatusEvent,
+            CheckItemEvent,
+        }
+        self.assertEqual(expected_types, set(self.renderer._dispatch.keys()))

--- a/emberblast/test/test_title_game_over_screens.py
+++ b/emberblast/test/test_title_game_over_screens.py
@@ -1,0 +1,49 @@
+"""Tests for TitleScreen and GameOverScreen."""
+
+from emberblast.test.test import BaseTestCase
+from emberblast.tui.screens.game_over import GameOverScreen
+from emberblast.tui.screens.title import LOGO, MENU_ITEMS, TitleScreen
+
+
+class TestTitleScreenStructure(BaseTestCase):
+    """Verify TitleScreen has expected structure."""
+
+    def test_has_compose(self):
+        self.assertHasAttr(TitleScreen, "compose")
+
+    def test_has_set_questioner(self):
+        self.assertHasAttr(TitleScreen, "set_questioner")
+
+    def test_has_on_key(self):
+        self.assertHasAttr(TitleScreen, "on_key")
+
+    def test_logo_is_nonempty_string(self):
+        self.assertIsInstance(LOGO, str)
+        self.assertGreater(len(LOGO), 0)
+
+    def test_menu_items(self):
+        self.assertIn("New Game", MENU_ITEMS)
+        self.assertIn("Continue", MENU_ITEMS)
+        self.assertIn("Quit", MENU_ITEMS)
+
+    def test_initial_menu_index(self):
+        screen = TitleScreen()
+        self.assertEqual(screen._menu_index, 0)
+
+
+class TestGameOverScreenStructure(BaseTestCase):
+    """Verify GameOverScreen has expected structure."""
+
+    def test_has_compose(self):
+        self.assertHasAttr(GameOverScreen, "compose")
+
+    def test_has_on_key(self):
+        self.assertHasAttr(GameOverScreen, "on_key")
+
+    def test_stores_winner_name(self):
+        screen = GameOverScreen(winner_name="Alice")
+        self.assertEqual(screen._winner_name, "Alice")
+
+    def test_initial_menu_index(self):
+        screen = GameOverScreen()
+        self.assertEqual(screen._menu_index, 0)

--- a/emberblast/test/test_tui_app.py
+++ b/emberblast/test/test_tui_app.py
@@ -46,6 +46,12 @@ class TestEmberblastAppStructure(BaseTestCase):
     def test_has_switch_to_battle(self):
         self.assertHasAttr(EmberblastApp, "switch_to_battle")
 
+    def test_has_update_hud(self):
+        self.assertHasAttr(EmberblastApp, "update_hud")
+
+    def test_has_update_enemies(self):
+        self.assertHasAttr(EmberblastApp, "update_enemies")
+
     def test_default_state(self):
         app = EmberblastApp()
         self.assertEqual(app._active_player_name, "")

--- a/emberblast/test/test_tui_app.py
+++ b/emberblast/test/test_tui_app.py
@@ -1,0 +1,55 @@
+"""Tests for EmberblastApp."""
+
+from emberblast.test.test import BaseTestCase
+from emberblast.tui.app import EmberblastApp
+
+
+class TestEmberblastAppStructure(BaseTestCase):
+    """Verify EmberblastApp has all required methods."""
+
+    def test_has_set_questioner(self):
+        self.assertHasAttr(EmberblastApp, "set_questioner")
+
+    def test_has_set_game_task(self):
+        self.assertHasAttr(EmberblastApp, "set_game_task")
+
+    def test_has_on_mount(self):
+        self.assertHasAttr(EmberblastApp, "on_mount")
+
+    def test_has_post_combat_log(self):
+        self.assertHasAttr(EmberblastApp, "post_combat_log")
+
+    def test_has_refresh_map(self):
+        self.assertHasAttr(EmberblastApp, "refresh_map")
+
+    def test_has_refresh_huds(self):
+        self.assertHasAttr(EmberblastApp, "refresh_huds")
+
+    def test_has_set_turn(self):
+        self.assertHasAttr(EmberblastApp, "set_turn")
+
+    def test_has_set_active_player(self):
+        self.assertHasAttr(EmberblastApp, "set_active_player")
+
+    def test_has_update_map_from_event(self):
+        self.assertHasAttr(EmberblastApp, "update_map_from_event")
+
+    def test_has_show_move_highlights(self):
+        self.assertHasAttr(EmberblastApp, "show_move_highlights")
+
+    def test_has_show_game_over(self):
+        self.assertHasAttr(EmberblastApp, "show_game_over")
+
+    def test_has_handle_question(self):
+        self.assertHasAttr(EmberblastApp, "handle_question")
+
+    def test_has_switch_to_battle(self):
+        self.assertHasAttr(EmberblastApp, "switch_to_battle")
+
+    def test_default_state(self):
+        app = EmberblastApp()
+        self.assertEqual(app._active_player_name, "")
+        self.assertEqual(app._current_turn, 0)
+        self.assertIsNone(app._questioner)
+        self.assertIsNone(app._game_task_fn)
+        self.assertEqual(app._friendly_names, [])

--- a/emberblast/test/test_tui_styles.py
+++ b/emberblast/test/test_tui_styles.py
@@ -1,0 +1,106 @@
+"""Tests for the TUI styles module."""
+
+from emberblast.test.test import BaseTestCase
+from emberblast.tui.styles import (
+    ACTION_COLORS,
+    LOG_COLORS,
+    TEAM_COLORS,
+    TERRAIN_COLORS,
+    TERRAIN_SYMBOLS,
+    get_player_token,
+    get_terrain_cell,
+)
+
+
+class TestTerrainSymbols(BaseTestCase):
+    """Tests for terrain symbol constants."""
+
+    def test_all_terrain_types_exist(self):
+        expected = {"plains", "wall", "water", "mountain", "forest"}
+        self.assertEqual(set(TERRAIN_SYMBOLS.keys()), expected)
+
+    def test_all_symbols_are_two_chars(self):
+        for terrain, symbol in TERRAIN_SYMBOLS.items():
+            self.assertEqual(len(symbol), 2, f"Symbol for {terrain} should be 2 chars")
+
+    def test_terrain_colors_match_terrain_symbols(self):
+        self.assertEqual(set(TERRAIN_COLORS.keys()), set(TERRAIN_SYMBOLS.keys()))
+
+
+class TestTeamColors(BaseTestCase):
+    """Tests for team color constants."""
+
+    def test_friendly_has_fg_and_bg(self):
+        self.assertIn("fg", TEAM_COLORS["friendly"])
+        self.assertIn("bg", TEAM_COLORS["friendly"])
+
+    def test_enemy_has_fg_and_bg(self):
+        self.assertIn("fg", TEAM_COLORS["enemy"])
+        self.assertIn("bg", TEAM_COLORS["enemy"])
+
+
+class TestLogColors(BaseTestCase):
+    """Tests for log color constants."""
+
+    def test_all_log_categories_exist(self):
+        expected = {
+            "damage",
+            "heal",
+            "narration",
+            "move",
+            "system",
+            "mana",
+            "death",
+            "xp",
+            "item",
+        }
+        self.assertEqual(set(LOG_COLORS.keys()), expected)
+
+
+class TestActionColors(BaseTestCase):
+    """Tests for action color constants."""
+
+    def test_all_action_types_exist(self):
+        expected = {
+            "move",
+            "attack",
+            "skill",
+            "defend",
+            "item",
+            "hide",
+            "search",
+            "equip",
+            "drop",
+            "check",
+            "pass",
+        }
+        self.assertEqual(set(ACTION_COLORS.keys()), expected)
+
+
+class TestGetPlayerToken(BaseTestCase):
+    """Tests for get_player_token function."""
+
+    def test_returns_two_char_string(self):
+        token = get_player_token("Gandalf", "wizard")
+        self.assertEqual(len(token), 2)
+
+    def test_returns_uppercase(self):
+        token = get_player_token("gandalf", "wizard")
+        self.assertEqual(token, "GW")
+
+    def test_uses_first_chars(self):
+        token = get_player_token("Aragorn", "ranger")
+        self.assertEqual(token, "AR")
+
+
+class TestGetTerrainCell(BaseTestCase):
+    """Tests for get_terrain_cell function."""
+
+    def test_known_terrain(self):
+        self.assertEqual(get_terrain_cell("wall"), "██")
+
+    def test_unknown_terrain_defaults_to_plains(self):
+        self.assertEqual(get_terrain_cell("lava"), TERRAIN_SYMBOLS["plains"])
+
+    def test_plains_terrain(self):
+        self.assertEqual(get_terrain_cell("plains"), "░░")

--- a/emberblast/test/test_tui_styles.py
+++ b/emberblast/test/test_tui_styles.py
@@ -43,7 +43,8 @@ class TestLogColors(BaseTestCase):
     """Tests for log color constants."""
 
     def test_all_log_categories_exist(self):
-        expected = {
+        # Must include all categories used by the renderer
+        required = {
             "damage",
             "heal",
             "narration",
@@ -53,8 +54,21 @@ class TestLogColors(BaseTestCase):
             "death",
             "xp",
             "item",
+            "turn",
+            "skill",
+            "dice",
+            "critical",
+            "victory",
+            "side_effect",
+            "trap",
+            "info",
+            "miss",
+            "warning",
+            "level_up",
+            "action",
+            "stats",
         }
-        self.assertEqual(set(LOG_COLORS.keys()), expected)
+        self.assertEqual(set(LOG_COLORS.keys()), required)
 
 
 class TestActionColors(BaseTestCase):

--- a/emberblast/tui/__init__.py
+++ b/emberblast/tui/__init__.py
@@ -1,0 +1,5 @@
+from emberblast.tui.app import EmberblastApp
+from emberblast.tui.questioner import TextualQuestioner
+from emberblast.tui.renderer import TextualRenderer
+
+__all__ = ["EmberblastApp", "TextualRenderer", "TextualQuestioner"]

--- a/emberblast/tui/app.py
+++ b/emberblast/tui/app.py
@@ -68,7 +68,7 @@ class EmberblastApp(App):
     def post_combat_log(self, message: str, category: str = "system") -> None:
         """Forward a message to the CombatLogWidget."""
         try:
-            log = self.query_one("#combat-log", CombatLogWidget)
+            log = self.screen.query_one("#combat-log", CombatLogWidget)
             log.add_entry(message, category)
         except Exception:
             logger.debug("CombatLogWidget not available", exc_info=True)
@@ -76,7 +76,7 @@ class EmberblastApp(App):
     def refresh_map(self) -> None:
         """Refresh the map widget."""
         try:
-            map_w = self.query_one("#map-widget", MapWidget)
+            map_w = self.screen.query_one("#map-widget", MapWidget)
             map_w.refresh()
         except Exception:
             logger.debug("MapWidget not available", exc_info=True)
@@ -84,7 +84,7 @@ class EmberblastApp(App):
     def refresh_huds(self) -> None:
         """Refresh the player HUD widget."""
         try:
-            hud = self.query_one("#player-hud", PlayerHUDWidget)
+            hud = self.screen.query_one("#player-hud", PlayerHUDWidget)
             hud.refresh()
         except Exception:
             logger.debug("PlayerHUDWidget not available", exc_info=True)
@@ -92,7 +92,7 @@ class EmberblastApp(App):
     def update_hud(self, player) -> None:
         """Update the player HUD with actual player data."""
         try:
-            hud = self.query_one("#player-hud", PlayerHUDWidget)
+            hud = self.screen.query_one("#player-hud", PlayerHUDWidget)
             hud.update_player(player)
         except Exception:
             logger.debug("PlayerHUDWidget not available for update", exc_info=True)
@@ -101,7 +101,7 @@ class EmberblastApp(App):
         """Update the turn header."""
         self._current_turn = turn
         try:
-            header = self.query_one("#turn-header", TurnHeader)
+            header = self.screen.query_one("#turn-header", TurnHeader)
             header.set_turn(turn)
         except Exception:
             logger.debug("TurnHeader not available", exc_info=True)
@@ -119,7 +119,8 @@ class EmberblastApp(App):
     ) -> None:
         """Update the MapWidget with event data."""
         try:
-            map_w = self.query_one("#map-widget", MapWidget)
+            screen = self.screen
+            map_w = screen.query_one("#map-widget", MapWidget)
             all_players = [player] + list(enemies)
             map_w.update_map(
                 matrix=matrix,
@@ -140,7 +141,7 @@ class EmberblastApp(App):
     ) -> None:
         """Highlight possible movement cells on the map."""
         try:
-            map_w = self.query_one("#map-widget", MapWidget)
+            map_w = self.screen.query_one("#map-widget", MapWidget)
             map_w._highlight_cells = set(possibilities)
             map_w.refresh()
         except Exception:
@@ -156,6 +157,10 @@ class EmberblastApp(App):
     def switch_to_battle(self, friendly_names: List[str]) -> None:
         """Transition from setup to the battle screen."""
         self._friendly_names = list(friendly_names)
+        # Pop the TitleScreen (and any setup screens) so BattleScreen becomes
+        # the active screen and widget queries resolve correctly.
+        while len(self.screen_stack) > 1:
+            self.pop_screen()
         battle = BattleScreen(friendly_names=friendly_names)
         if self._questioner:
             battle.set_questioner(self._questioner)

--- a/emberblast/tui/app.py
+++ b/emberblast/tui/app.py
@@ -1,0 +1,225 @@
+"""Main Textual application for Emberblast."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Callable, Coroutine, List, Optional
+
+from textual.app import App
+
+from emberblast.tui.screens.battle import BattleScreen, TurnHeader
+from emberblast.tui.screens.game_over import GameOverScreen
+from emberblast.tui.screens.setup import SetupScreen
+from emberblast.tui.screens.title import TitleScreen
+from emberblast.tui.widgets.combat_log import CombatLogWidget
+from emberblast.tui.widgets.map_grid import MapWidget
+from emberblast.tui.widgets.player_hud import PlayerHUDWidget
+
+# Question method names that route to battle screen
+_BATTLE_QUESTIONS = {
+    "ask_actions_questions",
+    "ask_where_to_move",
+    "ask_enemy_to_attack",
+    "ask_enemy_to_check",
+    "select_skill",
+    "select_item",
+    "confirm_item_selection",
+    "confirm_use_item_on_you",
+    "display_equipment_choices",
+    "ask_check_action",
+    "ask_attributes_to_improve",
+}
+
+
+class EmberblastApp(App):
+    """Main Textual app managing screens and bridging the game loop."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._questioner: Any = None
+        self._game_task_fn: Optional[Callable[[], Coroutine]] = None
+        self._game_task: Optional[asyncio.Task] = None
+        self._active_player_name: str = ""
+        self._current_turn: int = 0
+        self._friendly_names: List[str] = []
+
+    def set_questioner(self, questioner: Any) -> None:
+        """Wire the questioner instance."""
+        self._questioner = questioner
+
+    def set_game_task(self, coro_fn: Callable[[], Coroutine]) -> None:
+        """Store the game coroutine factory to schedule after mount."""
+        self._game_task_fn = coro_fn
+
+    async def on_mount(self) -> None:
+        """Push the title screen and schedule the game task."""
+        title = TitleScreen()
+        if self._questioner:
+            title.set_questioner(self._questioner)
+        await self.push_screen(title)
+
+        if self._game_task_fn:
+            self._game_task = asyncio.create_task(self._game_task_fn())
+
+    # ── Bridge methods called by TextualRenderer ──
+
+    def post_combat_log(self, message: str, category: str = "system") -> None:
+        """Forward a message to the CombatLogWidget."""
+        try:
+            log = self.query_one("#combat-log", CombatLogWidget)
+            log.add_entry(message, category)
+        except Exception:
+            pass
+
+    def refresh_map(self) -> None:
+        """Refresh the map widget."""
+        try:
+            map_w = self.query_one("#map-widget", MapWidget)
+            map_w.refresh()
+        except Exception:
+            pass
+
+    def refresh_huds(self) -> None:
+        """Refresh the player HUD widget."""
+        try:
+            hud = self.query_one("#player-hud", PlayerHUDWidget)
+            hud.refresh()
+        except Exception:
+            pass
+
+    def set_turn(self, turn: int) -> None:
+        """Update the turn header."""
+        self._current_turn = turn
+        try:
+            header = self.query_one("#turn-header", TurnHeader)
+            header.set_turn(turn)
+        except Exception:
+            pass
+
+    def set_active_player(self, player_name: str) -> None:
+        """Store the currently active player name."""
+        self._active_player_name = player_name
+
+    def update_map_from_event(
+        self,
+        player: Any,
+        enemies: list,
+        matrix: list,
+        size: int,
+    ) -> None:
+        """Update the MapWidget with event data."""
+        try:
+            map_w = self.query_one("#map-widget", MapWidget)
+            all_players = [player] + list(enemies)
+            map_w.update_map(
+                matrix=matrix,
+                size=size,
+                players=all_players,
+                active_player_name=self._active_player_name,
+                friendly_names=set(self._friendly_names),
+            )
+        except Exception:
+            pass
+
+    def show_move_highlights(
+        self,
+        position: str,
+        possibilities: list,
+        matrix: list,
+        size: int,
+    ) -> None:
+        """Highlight possible movement cells on the map."""
+        try:
+            map_w = self.query_one("#map-widget", MapWidget)
+            map_w._highlight_cells = set(possibilities)
+            map_w.refresh()
+        except Exception:
+            pass
+
+    def show_game_over(self, winner_name: str) -> None:
+        """Push the game over screen."""
+        screen = GameOverScreen(winner_name=winner_name)
+        self.push_screen(screen)
+
+    # ── Screen transition ──
+
+    def switch_to_battle(self, friendly_names: List[str]) -> None:
+        """Transition from setup to the battle screen."""
+        self._friendly_names = list(friendly_names)
+        battle = BattleScreen(friendly_names=friendly_names)
+        if self._questioner:
+            battle.set_questioner(self._questioner)
+        self.push_screen(battle)
+
+    # ── Question routing ──
+
+    def handle_question(self, method_name: str, **kwargs) -> None:
+        """Route a question from the questioner to the appropriate screen."""
+        if method_name == "perform_first_question":
+            self._handle_title_question(method_name, **kwargs)
+        elif method_name in ("perform_game_create_questions", "perform_character_creation_questions", "get_saved_game"):
+            self._handle_setup_question(method_name, **kwargs)
+        elif method_name in _BATTLE_QUESTIONS:
+            self._handle_battle_question(method_name, **kwargs)
+
+    def _handle_title_question(self, method_name: str, **kwargs) -> None:
+        """Forward question to the TitleScreen."""
+        try:
+            screen = self.screen
+            if isinstance(screen, TitleScreen) and self._questioner:
+                screen.set_questioner(self._questioner)
+        except Exception:
+            pass
+
+    def _handle_setup_question(self, method_name: str, **kwargs) -> None:
+        """Push a SetupScreen for the given question type."""
+        setup = SetupScreen(question_type=method_name)
+        if self._questioner:
+            setup.set_questioner(self._questioner)
+        self.push_screen(setup)
+
+    def _handle_battle_question(self, method_name: str, **kwargs) -> None:
+        """Forward question to the current BattleScreen."""
+        try:
+            screen = self.screen
+            if not isinstance(screen, BattleScreen):
+                return
+
+            if method_name == "ask_actions_questions":
+                actions = kwargs.get("actions_available", [])
+                screen.show_actions(actions)
+            elif method_name == "ask_where_to_move":
+                possibilities = kwargs.get("possibilities", [])
+                screen.show_choices(method_name, possibilities, possibilities)
+            elif method_name in ("ask_enemy_to_attack", "ask_enemy_to_check"):
+                enemies = kwargs.get("enemies", [])
+                labels = [f"{e.name} (HP:{e.life})" if hasattr(e, "life") else str(e) for e in enemies]
+                screen.show_choices(method_name, enemies, labels)
+            elif method_name == "select_skill":
+                skills = kwargs.get("available_skills", [])
+                labels = [f"{s.name} (MP:{s.mana_cost})" if hasattr(s, "mana_cost") else str(s) for s in skills]
+                screen.show_choices(method_name, skills, labels)
+            elif method_name == "select_item":
+                items = kwargs.get("items", [])
+                labels = [f"{i.name}" if hasattr(i, "name") else str(i) for i in items]
+                screen.show_choices(method_name, items, labels)
+            elif method_name in ("confirm_item_selection", "confirm_use_item_on_you"):
+                screen.show_confirm(method_name, "Are you sure?")
+            elif method_name == "display_equipment_choices":
+                player = kwargs.get("player")
+                if player and hasattr(player, "equipments"):
+                    equips = player.equipments
+                    labels = [f"{e.name}" if hasattr(e, "name") else str(e) for e in equips]
+                    screen.show_choices(method_name, equips, labels)
+            elif method_name == "ask_check_action":
+                show_items = kwargs.get("show_items", False)
+                choices = ["stats", "enemies"]
+                if show_items:
+                    choices.append("items")
+                choices.append("back")
+                screen.show_choices(method_name, choices, choices)
+            elif method_name == "ask_attributes_to_improve":
+                attrs = ["strength", "intelligence", "accuracy", "armour", "magic_resist", "will"]
+                screen.show_choices(method_name, attrs, attrs)
+        except Exception:
+            pass

--- a/emberblast/tui/app.py
+++ b/emberblast/tui/app.py
@@ -97,6 +97,14 @@ class EmberblastApp(App):
         except Exception:
             logger.debug("PlayerHUDWidget not available for update", exc_info=True)
 
+    def update_enemies(self, enemies: list) -> None:
+        """Update the enemy list in the HUD."""
+        try:
+            hud = self.screen.query_one("#player-hud", PlayerHUDWidget)
+            hud.update_enemies(enemies)
+        except Exception:
+            logger.debug("PlayerHUDWidget not available for enemy update", exc_info=True)
+
     def set_turn(self, turn: int) -> None:
         """Update the turn header."""
         self._current_turn = turn
@@ -105,6 +113,14 @@ class EmberblastApp(App):
             header.set_turn(turn)
         except Exception:
             logger.debug("TurnHeader not available", exc_info=True)
+
+    def set_map_name(self, name: str) -> None:
+        """Set the map name in the turn header."""
+        try:
+            header = self.screen.query_one("#turn-header", TurnHeader)
+            header.set_map_name(name)
+        except Exception:
+            logger.debug("TurnHeader not available for map name", exc_info=True)
 
     def set_active_player(self, player_name: str) -> None:
         """Store the currently active player name."""

--- a/emberblast/tui/app.py
+++ b/emberblast/tui/app.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any, Callable, Coroutine, List, Optional
 
 from textual.app import App
@@ -14,6 +15,8 @@ from emberblast.tui.screens.title import TitleScreen
 from emberblast.tui.widgets.combat_log import CombatLogWidget
 from emberblast.tui.widgets.map_grid import MapWidget
 from emberblast.tui.widgets.player_hud import PlayerHUDWidget
+
+logger = logging.getLogger(__name__)
 
 # Question method names that route to battle screen
 _BATTLE_QUESTIONS = {
@@ -69,7 +72,7 @@ class EmberblastApp(App):
             log = self.query_one("#combat-log", CombatLogWidget)
             log.add_entry(message, category)
         except Exception:
-            pass
+            logger.debug("CombatLogWidget not available", exc_info=True)
 
     def refresh_map(self) -> None:
         """Refresh the map widget."""
@@ -77,7 +80,7 @@ class EmberblastApp(App):
             map_w = self.query_one("#map-widget", MapWidget)
             map_w.refresh()
         except Exception:
-            pass
+            logger.debug("MapWidget not available", exc_info=True)
 
     def refresh_huds(self) -> None:
         """Refresh the player HUD widget."""
@@ -85,7 +88,7 @@ class EmberblastApp(App):
             hud = self.query_one("#player-hud", PlayerHUDWidget)
             hud.refresh()
         except Exception:
-            pass
+            logger.debug("PlayerHUDWidget not available", exc_info=True)
 
     def set_turn(self, turn: int) -> None:
         """Update the turn header."""
@@ -94,7 +97,7 @@ class EmberblastApp(App):
             header = self.query_one("#turn-header", TurnHeader)
             header.set_turn(turn)
         except Exception:
-            pass
+            logger.debug("TurnHeader not available", exc_info=True)
 
     def set_active_player(self, player_name: str) -> None:
         """Store the currently active player name."""
@@ -119,7 +122,7 @@ class EmberblastApp(App):
                 friendly_names=set(self._friendly_names),
             )
         except Exception:
-            pass
+            logger.debug("MapWidget not available for event update", exc_info=True)
 
     def show_move_highlights(
         self,
@@ -134,7 +137,7 @@ class EmberblastApp(App):
             map_w._highlight_cells = set(possibilities)
             map_w.refresh()
         except Exception:
-            pass
+            logger.debug("MapWidget not available for highlights", exc_info=True)
 
     def show_game_over(self, winner_name: str) -> None:
         """Push the game over screen."""
@@ -169,7 +172,7 @@ class EmberblastApp(App):
             if isinstance(screen, TitleScreen) and self._questioner:
                 screen.set_questioner(self._questioner)
         except Exception:
-            pass
+            logger.debug("TitleScreen not available", exc_info=True)
 
     def _handle_setup_question(self, method_name: str, **kwargs) -> None:
         """Push a SetupScreen for the given question type."""
@@ -207,19 +210,24 @@ class EmberblastApp(App):
                 screen.show_confirm(method_name, "Are you sure?")
             elif method_name == "display_equipment_choices":
                 player = kwargs.get("player")
-                if player and hasattr(player, "equipments"):
-                    equips = player.equipments
+                if player and hasattr(player, "bag"):
+                    equips = player.bag.get_equipments()
                     labels = [f"{e.name}" if hasattr(e, "name") else str(e) for e in equips]
-                    screen.show_choices(method_name, equips, labels)
+                    equips_with_cancel = list(equips) + [None]
+                    labels_with_cancel = labels + ["Cancel"]
+                    screen.show_choices(method_name, equips_with_cancel, labels_with_cancel)
             elif method_name == "ask_check_action":
                 show_items = kwargs.get("show_items", False)
-                choices = ["stats", "enemies"]
+                choices = ["map", "status", "enemy"]
+                labels = ["Map and Enemies", "My Status", "Single Enemy"]
                 if show_items:
-                    choices.append("items")
-                choices.append("back")
-                screen.show_choices(method_name, choices, choices)
+                    choices.append("item")
+                    labels.append("My Items")
+                choices.append("cancel")
+                labels.append("Cancel")
+                screen.show_choices(method_name, choices, labels)
             elif method_name == "ask_attributes_to_improve":
                 attrs = ["strength", "intelligence", "accuracy", "armour", "magic_resist", "will"]
                 screen.show_choices(method_name, attrs, attrs)
         except Exception:
-            pass
+            logger.debug("Battle question handling failed", exc_info=True)

--- a/emberblast/tui/app.py
+++ b/emberblast/tui/app.py
@@ -166,6 +166,27 @@ class EmberblastApp(App):
             battle.set_questioner(self._questioner)
         self.push_screen(battle)
 
+    # ── Highlight helpers ──
+
+    def _show_movement_highlights(self, possibilities: list) -> None:
+        """Highlight possible movement cells on the map."""
+        try:
+            map_w = self.screen.query_one("#map-widget", MapWidget)
+            map_w._highlight_cells = set(possibilities)
+            map_w.refresh()
+        except Exception:
+            logger.debug("MapWidget not available for movement highlights", exc_info=True)
+
+    def clear_highlights(self) -> None:
+        """Clear all highlight and flash cells on the map."""
+        try:
+            map_w = self.screen.query_one("#map-widget", MapWidget)
+            map_w._highlight_cells = set()
+            map_w._flash_cells = set()
+            map_w.refresh()
+        except Exception:
+            logger.debug("MapWidget not available for clearing highlights", exc_info=True)
+
     # ── Question routing ──
 
     def handle_question(self, method_name: str, **kwargs) -> None:
@@ -201,6 +222,8 @@ class EmberblastApp(App):
                 screen.show_actions(actions)
             elif method_name == "ask_where_to_move":
                 possibilities = kwargs.get("possibilities", [])
+                # Highlight movement cells on the map
+                self._show_movement_highlights(possibilities)
                 screen.show_choices(method_name, possibilities, possibilities)
             elif method_name in ("ask_enemy_to_attack", "ask_enemy_to_check"):
                 enemies = kwargs.get("enemies", [])

--- a/emberblast/tui/app.py
+++ b/emberblast/tui/app.py
@@ -10,7 +10,6 @@ from textual.app import App
 
 from emberblast.tui.screens.battle import BattleScreen, TurnHeader
 from emberblast.tui.screens.game_over import GameOverScreen
-from emberblast.tui.screens.setup import SetupScreen
 from emberblast.tui.screens.title import TitleScreen
 from emberblast.tui.widgets.combat_log import CombatLogWidget
 from emberblast.tui.widgets.map_grid import MapWidget
@@ -157,11 +156,14 @@ class EmberblastApp(App):
     # ── Question routing ──
 
     def handle_question(self, method_name: str, **kwargs) -> None:
-        """Route a question from the questioner to the appropriate screen."""
+        """Route a question from the questioner to the appropriate screen.
+
+        Note: perform_game_create_questions, perform_character_creation_questions,
+        and get_saved_game are handled directly by TextualQuestioner using
+        _ask_setup_list/_ask_setup_input, so they don't route through here.
+        """
         if method_name == "perform_first_question":
             self._handle_title_question(method_name, **kwargs)
-        elif method_name in ("perform_game_create_questions", "perform_character_creation_questions", "get_saved_game"):
-            self._handle_setup_question(method_name, **kwargs)
         elif method_name in _BATTLE_QUESTIONS:
             self._handle_battle_question(method_name, **kwargs)
 
@@ -173,13 +175,6 @@ class EmberblastApp(App):
                 screen.set_questioner(self._questioner)
         except Exception:
             logger.debug("TitleScreen not available", exc_info=True)
-
-    def _handle_setup_question(self, method_name: str, **kwargs) -> None:
-        """Push a SetupScreen for the given question type."""
-        setup = SetupScreen(question_type=method_name)
-        if self._questioner:
-            setup.set_questioner(self._questioner)
-        self.push_screen(setup)
 
     def _handle_battle_question(self, method_name: str, **kwargs) -> None:
         """Forward question to the current BattleScreen."""

--- a/emberblast/tui/app.py
+++ b/emberblast/tui/app.py
@@ -89,6 +89,14 @@ class EmberblastApp(App):
         except Exception:
             logger.debug("PlayerHUDWidget not available", exc_info=True)
 
+    def update_hud(self, player) -> None:
+        """Update the player HUD with actual player data."""
+        try:
+            hud = self.query_one("#player-hud", PlayerHUDWidget)
+            hud.update_player(player)
+        except Exception:
+            logger.debug("PlayerHUDWidget not available for update", exc_info=True)
+
     def set_turn(self, turn: int) -> None:
         """Update the turn header."""
         self._current_turn = turn

--- a/emberblast/tui/app.py
+++ b/emberblast/tui/app.py
@@ -11,9 +11,10 @@ from textual.app import App
 from emberblast.tui.screens.battle import BattleScreen, TurnHeader
 from emberblast.tui.screens.game_over import GameOverScreen
 from emberblast.tui.screens.title import TitleScreen
+from emberblast.tui.widgets.character_badge import CharacterBadgeWidget
 from emberblast.tui.widgets.combat_log import CombatLogWidget
+from emberblast.tui.widgets.enemy_panel import EnemyPanelWidget
 from emberblast.tui.widgets.map_grid import MapWidget
-from emberblast.tui.widgets.player_hud import PlayerHUDWidget
 
 logger = logging.getLogger(__name__)
 
@@ -82,28 +83,33 @@ class EmberblastApp(App):
             logger.debug("MapWidget not available", exc_info=True)
 
     def refresh_huds(self) -> None:
-        """Refresh the player HUD widget."""
+        """Refresh both the character badge and enemy panel."""
         try:
-            hud = self.screen.query_one("#player-hud", PlayerHUDWidget)
-            hud.refresh()
+            badge = self.screen.query_one("#character-badge", CharacterBadgeWidget)
+            badge.refresh()
         except Exception:
-            logger.debug("PlayerHUDWidget not available", exc_info=True)
+            logger.debug("CharacterBadgeWidget not available", exc_info=True)
+        try:
+            panel = self.screen.query_one("#enemy-panel", EnemyPanelWidget)
+            panel.refresh()
+        except Exception:
+            logger.debug("EnemyPanelWidget not available", exc_info=True)
 
     def update_hud(self, player) -> None:
-        """Update the player HUD with actual player data."""
+        """Update the character badge with actual player data."""
         try:
-            hud = self.screen.query_one("#player-hud", PlayerHUDWidget)
-            hud.update_player(player)
+            badge = self.screen.query_one("#character-badge", CharacterBadgeWidget)
+            badge.update_player(player)
         except Exception:
-            logger.debug("PlayerHUDWidget not available for update", exc_info=True)
+            logger.debug("CharacterBadgeWidget not available for update", exc_info=True)
 
     def update_enemies(self, enemies: list) -> None:
-        """Update the enemy list in the HUD."""
+        """Update the enemy panel."""
         try:
-            hud = self.screen.query_one("#player-hud", PlayerHUDWidget)
-            hud.update_enemies(enemies)
+            panel = self.screen.query_one("#enemy-panel", EnemyPanelWidget)
+            panel.update_enemies(enemies)
         except Exception:
-            logger.debug("PlayerHUDWidget not available for enemy update", exc_info=True)
+            logger.debug("EnemyPanelWidget not available for update", exc_info=True)
 
     def set_turn(self, turn: int) -> None:
         """Update the turn header."""
@@ -206,12 +212,7 @@ class EmberblastApp(App):
     # ── Question routing ──
 
     def handle_question(self, method_name: str, **kwargs) -> None:
-        """Route a question from the questioner to the appropriate screen.
-
-        Note: perform_game_create_questions, perform_character_creation_questions,
-        and get_saved_game are handled directly by TextualQuestioner using
-        _ask_setup_list/_ask_setup_input, so they don't route through here.
-        """
+        """Route a question from the questioner to the appropriate screen."""
         if method_name == "perform_first_question":
             self._handle_title_question(method_name, **kwargs)
         elif method_name in _BATTLE_QUESTIONS:
@@ -238,7 +239,6 @@ class EmberblastApp(App):
                 screen.show_actions(actions)
             elif method_name == "ask_where_to_move":
                 possibilities = kwargs.get("possibilities", [])
-                # Highlight movement cells on the map
                 self._show_movement_highlights(possibilities)
                 screen.show_choices(method_name, possibilities, possibilities)
             elif method_name in ("ask_enemy_to_attack", "ask_enemy_to_check"):

--- a/emberblast/tui/questioner.py
+++ b/emberblast/tui/questioner.py
@@ -1,6 +1,6 @@
 import asyncio
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 from emberblast.interface.interface import IEquipmentItem, IItem, IPlayer, IQuestioningSystem, ISkill
 
@@ -34,6 +34,33 @@ class TextualQuestioner(IQuestioningSystem):
         """Post question request to UI, then await the response."""
         self._app.handle_question(method_name, **kwargs)
         return await self._wait_for_response()
+
+    async def _ask_setup_list(self, title: str, choices: list, labels: Optional[list] = None):
+        """Push a SetupScreen, show a list, wait for selection, pop screen."""
+        from emberblast.tui.screens.setup import SetupScreen
+
+        setup = SetupScreen(question_type="sub_question")
+        setup.set_questioner(self)
+        await self._app.push_screen(setup)
+        # Small yield so the screen mounts before we call show_list
+        await asyncio.sleep(0.05)
+        setup.show_list(title, choices, labels)
+        result = await self._wait_for_response()
+        self._app.pop_screen()
+        return result
+
+    async def _ask_setup_input(self, title: str, placeholder: str = "Type here..."):
+        """Push a SetupScreen, show an input, wait for text, pop screen."""
+        from emberblast.tui.screens.setup import SetupScreen
+
+        setup = SetupScreen(question_type="sub_question")
+        setup.set_questioner(self)
+        await self._app.push_screen(setup)
+        await asyncio.sleep(0.05)
+        setup.show_input(title, placeholder)
+        result = await self._wait_for_response()
+        self._app.pop_screen()
+        return result
 
     async def ask_check_action(self, show_items: bool = False) -> Union[str, bool, list, str]:
         return await self._ask("ask_check_action", show_items=show_items)
@@ -71,15 +98,58 @@ class TextualQuestioner(IQuestioningSystem):
         return await self._ask("perform_first_question")
 
     async def perform_game_create_questions(self) -> Union[str, bool, list, dict]:
-        return await self._ask("perform_game_create_questions")
+        """Multi-step: ask game type, map, player count, bot count individually."""
+        game_type = await self._ask_setup_list(
+            "Select the Game Type",
+            ["Deathmatch", "Clan"],
+        )
+        game_map = await self._ask_setup_list(
+            "Select the Map",
+            ["Millstone Plains", "Firebend Vulcan", "Lerwick Mountains"],
+        )
+        controlled_players = await self._ask_setup_input(
+            "How many controlled players? (1-3)",
+            placeholder="1",
+        )
+        bots_number = await self._ask_setup_input(
+            "How many bots?",
+            placeholder="4",
+        )
+        return {
+            "game": game_type,
+            "map": game_map,
+            "controlled_players_number": controlled_players,
+            "bots_number": bots_number,
+        }
+
+    async def perform_character_creation_questions(self, existing_names: List[str]) -> Union[str, bool, list, dict]:
+        """Multi-step: ask name, race, job individually."""
+        from emberblast.conf import get_configuration
+        from emberblast.utils import JOBS_SECTION, RACES_SECTION
+
+        nickname = await self._ask_setup_input(
+            "Enter your character name",
+            placeholder="Hero",
+        )
+        races = list(get_configuration(RACES_SECTION).keys())
+        race = await self._ask_setup_list("Select your race", races)
+
+        jobs = list(get_configuration(JOBS_SECTION).keys())
+        job = await self._ask_setup_list("Select your job", jobs)
+
+        return {
+            "nickname": nickname,
+            "race": race,
+            "job": job,
+        }
 
     async def select_skill(self, available_skills: List[ISkill]) -> Union[str, bool, list, ISkill]:
         return await self._ask("select_skill", available_skills=available_skills)
 
     async def get_saved_game(self, normalized_files: List[Dict]) -> Union[str, bool, list, Path]:
-        return await self._ask("get_saved_game", normalized_files=normalized_files)
-
-    async def perform_character_creation_questions(
-        self, existing_names: List[str]
-    ) -> Union[str, bool, list, dict]:
-        return await self._ask("perform_character_creation_questions", existing_names=existing_names)
+        """Show saved game list via setup screen."""
+        labels = [f.get("name", str(f)) for f in normalized_files]
+        paths = [f.get("path") for f in normalized_files]
+        labels.append("Cancel")
+        paths.append("cancel")
+        return await self._ask_setup_list("Select a saved game", paths, labels)

--- a/emberblast/tui/questioner.py
+++ b/emberblast/tui/questioner.py
@@ -1,0 +1,85 @@
+import asyncio
+from pathlib import Path
+from typing import Dict, List, Union
+
+from emberblast.interface.interface import IEquipmentItem, IItem, IPlayer, IQuestioningSystem, ISkill
+
+
+class TextualQuestioner(IQuestioningSystem):
+    """Async questioning system that bridges the game loop with a Textual UI.
+
+    The game loop awaits answers via asyncio.Event. UI widgets call resolve()
+    to provide the user's response and unblock the game loop.
+    """
+
+    def __init__(self, app) -> None:
+        self._app = app
+        self._response = None
+        self._response_event = asyncio.Event()
+
+    def resolve(self, value) -> None:
+        """Called by UI widgets to provide the user's answer."""
+        self._response = value
+        self._response_event.set()
+
+    async def _wait_for_response(self):
+        """Block until resolve() is called, then return and reset."""
+        await self._response_event.wait()
+        self._response_event.clear()
+        result = self._response
+        self._response = None
+        return result
+
+    async def _ask(self, method_name: str, **kwargs):
+        """Post question request to UI, then await the response."""
+        self._app.handle_question(method_name, **kwargs)
+        return await self._wait_for_response()
+
+    async def ask_check_action(self, show_items: bool = False) -> Union[str, bool, list, str]:
+        return await self._ask("ask_check_action", show_items=show_items)
+
+    async def ask_actions_questions(self, actions_available: List[str]) -> Union[str, bool, list, str]:
+        return await self._ask("ask_actions_questions", actions_available=actions_available)
+
+    async def ask_enemy_to_check(self, enemies: List[IPlayer]) -> Union[str, bool, list, IPlayer]:
+        return await self._ask("ask_enemy_to_check", enemies=enemies)
+
+    async def ask_enemy_to_attack(
+        self, enemies: List[IPlayer], skill_type: str = ""
+    ) -> Union[str, bool, list, IPlayer]:
+        return await self._ask("ask_enemy_to_attack", enemies=enemies, skill_type=skill_type)
+
+    async def select_item(self, items: List[IItem]) -> Union[str, bool, list, IItem]:
+        return await self._ask("select_item", items=items)
+
+    async def confirm_item_selection(self) -> Union[str, bool, list, bool]:
+        return await self._ask("confirm_item_selection")
+
+    async def confirm_use_item_on_you(self) -> Union[str, bool, list, bool]:
+        return await self._ask("confirm_use_item_on_you")
+
+    async def display_equipment_choices(self, player: IPlayer) -> Union[str, bool, list, IEquipmentItem]:
+        return await self._ask("display_equipment_choices", player=player)
+
+    async def ask_attributes_to_improve(self) -> Union[str, bool, list, List]:
+        return await self._ask("ask_attributes_to_improve")
+
+    async def ask_where_to_move(self, possibilities: List[str]) -> Union[str, bool, list, str]:
+        return await self._ask("ask_where_to_move", possibilities=possibilities)
+
+    async def perform_first_question(self) -> Union[str, bool, list, str]:
+        return await self._ask("perform_first_question")
+
+    async def perform_game_create_questions(self) -> Union[str, bool, list, dict]:
+        return await self._ask("perform_game_create_questions")
+
+    async def select_skill(self, available_skills: List[ISkill]) -> Union[str, bool, list, ISkill]:
+        return await self._ask("select_skill", available_skills=available_skills)
+
+    async def get_saved_game(self, normalized_files: List[Dict]) -> Union[str, bool, list, Path]:
+        return await self._ask("get_saved_game", normalized_files=normalized_files)
+
+    async def perform_character_creation_questions(
+        self, existing_names: List[str]
+    ) -> Union[str, bool, list, dict]:
+        return await self._ask("perform_character_creation_questions", existing_names=existing_names)

--- a/emberblast/tui/renderer.py
+++ b/emberblast/tui/renderer.py
@@ -1,0 +1,311 @@
+from emberblast.events import (
+    AreaDamageEvent,
+    CheckItemEvent,
+    DamageEvent,
+    DeathEvent,
+    DiceRollEvent,
+    EnemyStatusEvent,
+    EventAction,
+    GameEvent,
+    GreetingsEvent,
+    HealEvent,
+    ItemEvent,
+    ItemFoundEvent,
+    IteratedSideEffectEvent,
+    LevelUpEvent,
+    LineSeparatorEvent,
+    LowManaEvent,
+    MapInfoEvent,
+    MissedAttackEvent,
+    MoveEvent,
+    MovingPossibilitiesEvent,
+    NarrationEvent,
+    NewCharacterEvent,
+    NoFoesEvent,
+    PlayerFailStoleItemEvent,
+    PlayerStatsEvent,
+    PlayerStoleItemEvent,
+    PlayerTurnEvent,
+    SideEffectEndedEvent,
+    SideEffectEvent,
+    SkillEvent,
+    SpentManaEvent,
+    TrapActivatedEvent,
+    TurnStartEvent,
+    UseItemEvent,
+    VictoryEvent,
+    XPEarnedEvent,
+)
+from emberblast.interface.interface import IRenderer
+
+
+class TextualRenderer(IRenderer):
+    """Renderer that dispatches GameEvent objects to a Textual app's widgets."""
+
+    def __init__(self, app) -> None:
+        self._app = app
+        self._dispatch = {
+            GreetingsEvent: self._render_greetings,
+            TurnStartEvent: self._render_turn_start,
+            PlayerTurnEvent: self._render_player_turn,
+            LineSeparatorEvent: self._render_line_separator,
+            MoveEvent: self._render_move,
+            DamageEvent: self._render_damage,
+            HealEvent: self._render_heal,
+            SkillEvent: self._render_skill,
+            SpentManaEvent: self._render_spent_mana,
+            ItemEvent: self._render_item,
+            UseItemEvent: self._render_use_item,
+            DiceRollEvent: self._render_dice_roll,
+            NarrationEvent: self._render_narration,
+            DeathEvent: self._render_death,
+            VictoryEvent: self._render_victory,
+            SideEffectEvent: self._render_side_effect,
+            SideEffectEndedEvent: self._render_side_effect_ended,
+            IteratedSideEffectEvent: self._render_iterated_side_effect,
+            ItemFoundEvent: self._render_item_found,
+            LevelUpEvent: self._render_level_up,
+            XPEarnedEvent: self._render_xp_earned,
+            EventAction: self._render_event_action,
+            LowManaEvent: self._render_low_mana,
+            MissedAttackEvent: self._render_missed_attack,
+            TrapActivatedEvent: self._render_trap_activated,
+            NoFoesEvent: self._render_no_foes,
+            AreaDamageEvent: self._render_area_damage,
+            PlayerStoleItemEvent: self._render_player_stole_item,
+            PlayerFailStoleItemEvent: self._render_player_fail_stole_item,
+            NewCharacterEvent: self._render_new_character,
+            MapInfoEvent: self._render_map_info,
+            MovingPossibilitiesEvent: self._render_moving_possibilities,
+            PlayerStatsEvent: self._render_player_stats,
+            EnemyStatusEvent: self._render_enemy_status,
+            CheckItemEvent: self._render_check_item,
+        }
+
+    def render(self, event: GameEvent) -> None:
+        handler = self._dispatch.get(type(event))
+        if handler:
+            handler(event)
+
+    def _render_greetings(self, event: GreetingsEvent) -> None:
+        self._app.post_combat_log("Welcome to EMBERBLAST!", "system")
+
+    def _render_turn_start(self, event: TurnStartEvent) -> None:
+        self._app.set_turn(event.turn)
+        self._app.post_combat_log(f"Turn {event.turn} — Embrace Yourselves!", "turn")
+
+    def _render_player_turn(self, event: PlayerTurnEvent) -> None:
+        self._app.set_active_player(event.player_name)
+        self._app.post_combat_log(f"{event.player_name}'s turn!", "turn")
+
+    def _render_line_separator(self, event: LineSeparatorEvent) -> None:
+        self._app.post_combat_log("---", "system")
+
+    def _render_move(self, event: MoveEvent) -> None:
+        if event.from_position and event.to_position:
+            msg = f"{event.player_name} moved from {event.from_position} to {event.to_position}"
+        else:
+            msg = f"{event.player_name} has just moved to another position"
+        self._app.post_combat_log(msg, "move")
+        self._app.refresh_map()
+
+    def _render_damage(self, event: DamageEvent) -> None:
+        msg = f"{event.attacker_name} inflicted {event.damage} damage on {event.target_name}"
+        self._app.post_combat_log(msg, "damage")
+        if not event.target_alive:
+            self._app.post_combat_log(f"{event.target_name} is now dead", "death")
+        else:
+            self._app.post_combat_log(f"{event.target_name} now has {event.target_life} HP", "damage")
+        self._app.refresh_huds()
+
+    def _render_heal(self, event: HealEvent) -> None:
+        target = "itself" if event.healer_name == event.target_name else event.target_name
+        self._app.post_combat_log(
+            f"{event.healer_name} healed {target} for {event.amount} HP!", "heal"
+        )
+        self._app.post_combat_log(f"{event.target_name} now has {event.target_life} HP", "heal")
+        self._app.refresh_huds()
+
+    def _render_skill(self, event: SkillEvent) -> None:
+        self._app.post_combat_log(
+            f"{event.caster_name} casts {event.skill_name} (cost: {event.mana_cost} MP)", "skill"
+        )
+
+    def _render_spent_mana(self, event: SpentManaEvent) -> None:
+        self._app.post_combat_log(
+            f"{event.player_name} casted {event.skill_name} for {event.amount} mana.", "skill"
+        )
+        self._app.refresh_huds()
+
+    def _render_item(self, event: ItemEvent) -> None:
+        target = "himself" if event.target_name == event.player_name else event.target_name
+        self._app.post_combat_log(
+            f"{event.player_name} uses {event.item_name} on {target}", "item"
+        )
+
+    def _render_use_item(self, event: UseItemEvent) -> None:
+        target = "himself" if event.target_name == event.player_name else event.target_name
+        self._app.post_combat_log(f"{event.player_name} used {event.item_name} on {target}", "item")
+
+    def _render_dice_roll(self, event: DiceRollEvent) -> None:
+        self._app.post_combat_log(
+            f"{event.player_name} rolled the dice and got {event.result}!", "dice"
+        )
+        if event.is_critical:
+            self._app.post_combat_log(f"Critical {event.kind}! Massive damage!", "critical")
+
+    def _render_narration(self, event: NarrationEvent) -> None:
+        self._app.post_combat_log(f'{event.player_name}: "{event.text}"', "narration")
+
+    def _render_death(self, event: DeathEvent) -> None:
+        self._app.post_combat_log(f"{event.player_name} is now dead", "death")
+        self._app.refresh_huds()
+        self._app.refresh_map()
+
+    def _render_victory(self, event: VictoryEvent) -> None:
+        self._app.post_combat_log(f"{event.player_name} won the game!", "victory")
+        self._app.show_game_over(event.player_name)
+
+    def _render_side_effect(self, event: SideEffectEvent) -> None:
+        if event.effect_type == "debuff" and event.occurrence == "constant":
+            status = "debuffed"
+        elif event.effect_type == "debuff" and event.occurrence == "iterated":
+            status = "inflicted"
+        else:
+            status = "buffed"
+        self._app.post_combat_log(
+            f"{event.player_name} has been {status} with {event.effect_name}.", "side_effect"
+        )
+
+    def _render_side_effect_ended(self, event: SideEffectEndedEvent) -> None:
+        self._app.post_combat_log(
+            f"{event.effect_name} has ended for {event.player_name}", "side_effect"
+        )
+
+    def _render_iterated_side_effect(self, event: IteratedSideEffectEvent) -> None:
+        status = "increase" if event.effect_type == "buff" else "decrease"
+        attribute = (
+            "life"
+            if event.attribute == "health_points"
+            else ("mana" if event.attribute == "magic_points" else event.attribute)
+        )
+        self._app.post_combat_log(
+            f"{event.player_name} affected by {event.effect_name}, "
+            f"will {status} {attribute} by {event.value}/turn. "
+            f"{event.turns_remaining} turns left.",
+            "side_effect",
+        )
+
+    def _render_item_found(self, event: ItemFoundEvent) -> None:
+        if event.found:
+            self._app.post_combat_log(
+                f"{event.player_name} found a {event.item_tier} item! {event.item_name}", "item"
+            )
+        else:
+            self._app.post_combat_log(
+                f"{event.player_name} tried to find an item, but nothing was found!", "item"
+            )
+
+    def _render_level_up(self, event: LevelUpEvent) -> None:
+        self._app.post_combat_log(
+            f"{event.player_name} leveled up to {event.new_level}!", "level_up"
+        )
+        self._app.refresh_huds()
+
+    def _render_xp_earned(self, event: XPEarnedEvent) -> None:
+        if event.kill_target:
+            self._app.post_combat_log(
+                f"{event.player_name} earned {event.xp} XP by killing {event.kill_target}!", "xp"
+            )
+        else:
+            self._app.post_combat_log(f"{event.player_name} earned {event.xp} XP!", "xp")
+
+    def _render_event_action(self, event: EventAction) -> None:
+        label = event.event.upper()
+        self._app.post_combat_log(f"{label}:", "action")
+
+    def _render_low_mana(self, event: LowManaEvent) -> None:
+        self._app.post_combat_log(
+            f"{event.player_name} has {event.mana} mana, consider healing it.", "warning"
+        )
+
+    def _render_missed_attack(self, event: MissedAttackEvent) -> None:
+        self._app.post_combat_log(
+            f"{event.attacker_name} tried to attack {event.target_name} but missed.", "miss"
+        )
+
+    def _render_trap_activated(self, event: TrapActivatedEvent) -> None:
+        self._app.post_combat_log(f"{event.player_name} has fallen into a trap!", "trap")
+        for name in event.side_effect_names:
+            self._app.post_combat_log(f"  - {name}", "trap")
+
+    def _render_no_foes(self, event: NoFoesEvent) -> None:
+        self._app.post_combat_log(event.message, "info")
+
+    def _render_area_damage(self, event: AreaDamageEvent) -> None:
+        self._app.post_combat_log(
+            f"{event.skill_name} is an area {event.skill_kind} skill, hitting:", "skill"
+        )
+        for player in event.affected_players:
+            self._app.post_combat_log(
+                f"  {player.name}({player.job.get_name()}) at {player.position} with {player.life} HP",
+                "damage",
+            )
+        self._app.refresh_huds()
+
+    def _render_player_stole_item(self, event: PlayerStoleItemEvent) -> None:
+        self._app.post_combat_log(
+            f"{event.player_name} stole {event.item_name} ({event.tier}) from {event.foe_name}!",
+            "item",
+        )
+
+    def _render_player_fail_stole_item(self, event: PlayerFailStoleItemEvent) -> None:
+        self._app.post_combat_log(
+            f"{event.player_name} failed to steal from {event.foe_name}", "item"
+        )
+
+    def _render_new_character(self, event: NewCharacterEvent) -> None:
+        self._app.post_combat_log(
+            f"Creating controlled character number: {event.number}...", "system"
+        )
+
+    def _render_map_info(self, event: MapInfoEvent) -> None:
+        self._app.update_map_from_event(
+            event.current_player, event.enemies, event.matrix, event.size
+        )
+
+    def _render_moving_possibilities(self, event: MovingPossibilitiesEvent) -> None:
+        self._app.show_move_highlights(
+            event.player_position, event.possibilities, event.matrix, event.size
+        )
+
+    def _render_player_stats(self, event: PlayerStatsEvent) -> None:
+        p = event.player
+        self._app.post_combat_log(
+            f"{p.name} Lv.{p.level} HP:{p.life}/{p.health_points} MP:{p.mana}/{p.magic_points} "
+            f"STR:{p.strength} INT:{p.intelligence} ACC:{p.accuracy} "
+            f"ARM:{p.armour} RES:{p.magic_resist} SPD:{p.move_speed} WILL:{p.will}",
+            "stats",
+        )
+
+    def _render_enemy_status(self, event: EnemyStatusEvent) -> None:
+        e = event.enemy
+        self._app.post_combat_log(
+            f"{e.name} ({e.job.get_name()}) Pos:{e.position} Lv.{e.level} "
+            f"HP:{e.life}/{e.health_points} MP:{e.mana}/{e.magic_points} "
+            f"STR:{e.strength} INT:{e.intelligence} ACC:{e.accuracy} "
+            f"ARM:{e.armour} RES:{e.magic_resist} SPD:{e.move_speed} WILL:{e.will}",
+            "stats",
+        )
+
+    def _render_check_item(self, event: CheckItemEvent) -> None:
+        item = event.item
+        lines = [f"{item.name} ({item.tier} tier)", item.description, f"Weight: {item.weight} kg"]
+        if hasattr(item, "base") and hasattr(item, "attribute"):
+            lines.append(f"+{item.base} {item.attribute}")
+        if hasattr(item, "side_effects") and item.side_effects:
+            lines.append("Side effects:")
+            for se in item.side_effects:
+                prefix = f"+{se.base}" if se.effect_type == "buff" else f"-{se.base}"
+                lines.append(f"  {se.name}: {prefix} {se.attribute} ({se.duration} turns, {se.occurrence})")
+        self._app.post_combat_log("\n".join(lines), "item")

--- a/emberblast/tui/renderer.py
+++ b/emberblast/tui/renderer.py
@@ -112,6 +112,13 @@ class TextualRenderer(IRenderer):
 
     def _render_turn_start(self, event: TurnStartEvent) -> None:
         self._app.set_turn(event.turn)
+        # Update combat log turn tracker so entries get [T#] prefix
+        try:
+            log = self._app.screen.query_one("#combat-log")
+            if hasattr(log, "set_turn"):
+                log.set_turn(event.turn)
+        except Exception:
+            pass
         self._app.post_combat_log(f"Turn {event.turn} — Embrace Yourselves!", "turn")
 
     def _render_player_turn(self, event: PlayerTurnEvent) -> None:

--- a/emberblast/tui/renderer.py
+++ b/emberblast/tui/renderer.py
@@ -109,9 +109,7 @@ class TextualRenderer(IRenderer):
 
             if active:
                 others = [p for p in all_alive if p != active]
-                self._app.update_map_from_event(
-                    active, others, game.game_map.graph.matrix, game.game_map.size
-                )
+                self._app.update_map_from_event(active, others, game.game_map.graph.matrix, game.game_map.size)
 
             # Always update HUD with the controlled player, not whoever's turn it is
             friendly_names = set(getattr(self._app, "_friendly_names", []))

--- a/emberblast/tui/renderer.py
+++ b/emberblast/tui/renderer.py
@@ -213,9 +213,11 @@ class TextualRenderer(IRenderer):
         else:
             status = "buffed"
         self._app.post_combat_log(f"{event.player_name} has been {status} with {event.effect_name}.", "side_effect")
+        self._app.refresh_huds()
 
     def _render_side_effect_ended(self, event: SideEffectEndedEvent) -> None:
         self._app.post_combat_log(f"{event.effect_name} has ended for {event.player_name}", "side_effect")
+        self._app.refresh_huds()
 
     def _render_iterated_side_effect(self, event: IteratedSideEffectEvent) -> None:
         status = "increase" if event.effect_type == "buff" else "decrease"
@@ -230,6 +232,7 @@ class TextualRenderer(IRenderer):
             f"{event.turns_remaining} turns left.",
             "side_effect",
         )
+        self._app.refresh_huds()
 
     def _render_item_found(self, event: ItemFoundEvent) -> None:
         if event.found:
@@ -261,6 +264,7 @@ class TextualRenderer(IRenderer):
         self._app.post_combat_log(f"{event.player_name} has fallen into a trap!", "trap")
         for name in event.side_effect_names:
             self._app.post_combat_log(f"  - {name}", "trap")
+        self._app.refresh_huds()
 
     def _render_no_foes(self, event: NoFoesEvent) -> None:
         self._app.post_combat_log(event.message, "info")

--- a/emberblast/tui/renderer.py
+++ b/emberblast/tui/renderer.py
@@ -88,22 +88,44 @@ class TextualRenderer(IRenderer):
             handler(event)
 
     def _refresh_game_state(self, player_name: str) -> None:
-        """Pull current map/player data from the orchestrator and update widgets."""
+        """Pull current map/player data from the orchestrator and update widgets.
+
+        Always shows the controlled player in the HUD, regardless of whose turn it is.
+        The map shows all alive players with the active player highlighted.
+        """
         orch = getattr(self._app, "_orchestrator", None)
         if not orch:
             return
         try:
             game = orch.game
-            # Find the active player
+            all_alive = game.get_all_alive_players()
+
+            # Find the active player (whose turn it is) for map highlighting
             active = None
-            for p in game.get_all_alive_players():
+            for p in all_alive:
                 if p.name == player_name:
                     active = p
                     break
+
             if active:
-                enemies = [p for p in game.get_all_alive_players() if p != active]
-                self._app.update_map_from_event(active, enemies, game.game_map.graph.matrix, game.game_map.size)
-                self._app.update_hud(active)
+                others = [p for p in all_alive if p != active]
+                self._app.update_map_from_event(
+                    active, others, game.game_map.graph.matrix, game.game_map.size
+                )
+
+            # Always update HUD with the controlled player, not whoever's turn it is
+            friendly_names = set(getattr(self._app, "_friendly_names", []))
+            controlled = None
+            enemies_for_hud = []
+            for p in all_alive:
+                if p.name in friendly_names:
+                    controlled = p
+                else:
+                    enemies_for_hud.append(p)
+
+            if controlled:
+                self._app.update_hud(controlled)
+                self._app.update_enemies(enemies_for_hud)
         except Exception:
             pass
 

--- a/emberblast/tui/renderer.py
+++ b/emberblast/tui/renderer.py
@@ -87,6 +87,26 @@ class TextualRenderer(IRenderer):
         if handler:
             handler(event)
 
+    def _refresh_game_state(self, player_name: str) -> None:
+        """Pull current map/player data from the orchestrator and update widgets."""
+        orch = getattr(self._app, "_orchestrator", None)
+        if not orch:
+            return
+        try:
+            game = orch.game
+            # Find the active player
+            active = None
+            for p in game.get_all_alive_players():
+                if p.name == player_name:
+                    active = p
+                    break
+            if active:
+                enemies = [p for p in game.get_all_alive_players() if p != active]
+                self._app.update_map_from_event(active, enemies, game.game_map.graph.matrix, game.game_map.size)
+                self._app.update_hud(active)
+        except Exception:
+            pass
+
     def _render_greetings(self, event: GreetingsEvent) -> None:
         self._app.post_combat_log("Welcome to EMBERBLAST!", "system")
 
@@ -97,6 +117,8 @@ class TextualRenderer(IRenderer):
     def _render_player_turn(self, event: PlayerTurnEvent) -> None:
         self._app.set_active_player(event.player_name)
         self._app.post_combat_log(f"{event.player_name}'s turn!", "turn")
+        # Refresh map and HUD at each player turn
+        self._refresh_game_state(event.player_name)
 
     def _render_line_separator(self, event: LineSeparatorEvent) -> None:
         self._app.post_combat_log("---", "system")
@@ -120,37 +142,27 @@ class TextualRenderer(IRenderer):
 
     def _render_heal(self, event: HealEvent) -> None:
         target = "itself" if event.healer_name == event.target_name else event.target_name
-        self._app.post_combat_log(
-            f"{event.healer_name} healed {target} for {event.amount} HP!", "heal"
-        )
+        self._app.post_combat_log(f"{event.healer_name} healed {target} for {event.amount} HP!", "heal")
         self._app.post_combat_log(f"{event.target_name} now has {event.target_life} HP", "heal")
         self._app.refresh_huds()
 
     def _render_skill(self, event: SkillEvent) -> None:
-        self._app.post_combat_log(
-            f"{event.caster_name} casts {event.skill_name} (cost: {event.mana_cost} MP)", "skill"
-        )
+        self._app.post_combat_log(f"{event.caster_name} casts {event.skill_name} (cost: {event.mana_cost} MP)", "skill")
 
     def _render_spent_mana(self, event: SpentManaEvent) -> None:
-        self._app.post_combat_log(
-            f"{event.player_name} casted {event.skill_name} for {event.amount} mana.", "skill"
-        )
+        self._app.post_combat_log(f"{event.player_name} casted {event.skill_name} for {event.amount} mana.", "skill")
         self._app.refresh_huds()
 
     def _render_item(self, event: ItemEvent) -> None:
         target = "himself" if event.target_name == event.player_name else event.target_name
-        self._app.post_combat_log(
-            f"{event.player_name} uses {event.item_name} on {target}", "item"
-        )
+        self._app.post_combat_log(f"{event.player_name} uses {event.item_name} on {target}", "item")
 
     def _render_use_item(self, event: UseItemEvent) -> None:
         target = "himself" if event.target_name == event.player_name else event.target_name
         self._app.post_combat_log(f"{event.player_name} used {event.item_name} on {target}", "item")
 
     def _render_dice_roll(self, event: DiceRollEvent) -> None:
-        self._app.post_combat_log(
-            f"{event.player_name} rolled the dice and got {event.result}!", "dice"
-        )
+        self._app.post_combat_log(f"{event.player_name} rolled the dice and got {event.result}!", "dice")
         if event.is_critical:
             self._app.post_combat_log(f"Critical {event.kind}! Massive damage!", "critical")
 
@@ -173,14 +185,10 @@ class TextualRenderer(IRenderer):
             status = "inflicted"
         else:
             status = "buffed"
-        self._app.post_combat_log(
-            f"{event.player_name} has been {status} with {event.effect_name}.", "side_effect"
-        )
+        self._app.post_combat_log(f"{event.player_name} has been {status} with {event.effect_name}.", "side_effect")
 
     def _render_side_effect_ended(self, event: SideEffectEndedEvent) -> None:
-        self._app.post_combat_log(
-            f"{event.effect_name} has ended for {event.player_name}", "side_effect"
-        )
+        self._app.post_combat_log(f"{event.effect_name} has ended for {event.player_name}", "side_effect")
 
     def _render_iterated_side_effect(self, event: IteratedSideEffectEvent) -> None:
         status = "increase" if event.effect_type == "buff" else "decrease"
@@ -198,25 +206,17 @@ class TextualRenderer(IRenderer):
 
     def _render_item_found(self, event: ItemFoundEvent) -> None:
         if event.found:
-            self._app.post_combat_log(
-                f"{event.player_name} found a {event.item_tier} item! {event.item_name}", "item"
-            )
+            self._app.post_combat_log(f"{event.player_name} found a {event.item_tier} item! {event.item_name}", "item")
         else:
-            self._app.post_combat_log(
-                f"{event.player_name} tried to find an item, but nothing was found!", "item"
-            )
+            self._app.post_combat_log(f"{event.player_name} tried to find an item, but nothing was found!", "item")
 
     def _render_level_up(self, event: LevelUpEvent) -> None:
-        self._app.post_combat_log(
-            f"{event.player_name} leveled up to {event.new_level}!", "level_up"
-        )
+        self._app.post_combat_log(f"{event.player_name} leveled up to {event.new_level}!", "level_up")
         self._app.refresh_huds()
 
     def _render_xp_earned(self, event: XPEarnedEvent) -> None:
         if event.kill_target:
-            self._app.post_combat_log(
-                f"{event.player_name} earned {event.xp} XP by killing {event.kill_target}!", "xp"
-            )
+            self._app.post_combat_log(f"{event.player_name} earned {event.xp} XP by killing {event.kill_target}!", "xp")
         else:
             self._app.post_combat_log(f"{event.player_name} earned {event.xp} XP!", "xp")
 
@@ -225,14 +225,10 @@ class TextualRenderer(IRenderer):
         self._app.post_combat_log(f"{label}:", "action")
 
     def _render_low_mana(self, event: LowManaEvent) -> None:
-        self._app.post_combat_log(
-            f"{event.player_name} has {event.mana} mana, consider healing it.", "warning"
-        )
+        self._app.post_combat_log(f"{event.player_name} has {event.mana} mana, consider healing it.", "warning")
 
     def _render_missed_attack(self, event: MissedAttackEvent) -> None:
-        self._app.post_combat_log(
-            f"{event.attacker_name} tried to attack {event.target_name} but missed.", "miss"
-        )
+        self._app.post_combat_log(f"{event.attacker_name} tried to attack {event.target_name} but missed.", "miss")
 
     def _render_trap_activated(self, event: TrapActivatedEvent) -> None:
         self._app.post_combat_log(f"{event.player_name} has fallen into a trap!", "trap")
@@ -243,9 +239,7 @@ class TextualRenderer(IRenderer):
         self._app.post_combat_log(event.message, "info")
 
     def _render_area_damage(self, event: AreaDamageEvent) -> None:
-        self._app.post_combat_log(
-            f"{event.skill_name} is an area {event.skill_kind} skill, hitting:", "skill"
-        )
+        self._app.post_combat_log(f"{event.skill_name} is an area {event.skill_kind} skill, hitting:", "skill")
         for player in event.affected_players:
             self._app.post_combat_log(
                 f"  {player.name}({player.job.get_name()}) at {player.position} with {player.life} HP",
@@ -260,24 +254,16 @@ class TextualRenderer(IRenderer):
         )
 
     def _render_player_fail_stole_item(self, event: PlayerFailStoleItemEvent) -> None:
-        self._app.post_combat_log(
-            f"{event.player_name} failed to steal from {event.foe_name}", "item"
-        )
+        self._app.post_combat_log(f"{event.player_name} failed to steal from {event.foe_name}", "item")
 
     def _render_new_character(self, event: NewCharacterEvent) -> None:
-        self._app.post_combat_log(
-            f"Creating controlled character number: {event.number}...", "system"
-        )
+        self._app.post_combat_log(f"Creating controlled character number: {event.number}...", "system")
 
     def _render_map_info(self, event: MapInfoEvent) -> None:
-        self._app.update_map_from_event(
-            event.current_player, event.enemies, event.matrix, event.size
-        )
+        self._app.update_map_from_event(event.current_player, event.enemies, event.matrix, event.size)
 
     def _render_moving_possibilities(self, event: MovingPossibilitiesEvent) -> None:
-        self._app.show_move_highlights(
-            event.player_position, event.possibilities, event.matrix, event.size
-        )
+        self._app.show_move_highlights(event.player_position, event.possibilities, event.matrix, event.size)
 
     def _render_player_stats(self, event: PlayerStatsEvent) -> None:
         p = event.player

--- a/emberblast/tui/screens/battle.py
+++ b/emberblast/tui/screens/battle.py
@@ -10,9 +10,10 @@ from textual.screen import Screen
 from textual.widgets import Static
 
 from emberblast.tui.widgets.action_bar import ACTION_KEYS, ActionBarWidget
+from emberblast.tui.widgets.character_badge import CharacterBadgeWidget
 from emberblast.tui.widgets.combat_log import CombatLogWidget
+from emberblast.tui.widgets.enemy_panel import EnemyPanelWidget
 from emberblast.tui.widgets.map_grid import MapWidget
-from emberblast.tui.widgets.player_hud import PlayerHUDWidget
 
 # Reverse lookup: key letter -> action name
 _KEY_TO_ACTION = {v.lower(): k for k, v in ACTION_KEYS.items()}
@@ -63,21 +64,24 @@ class BattleScreen(Screen):
     BattleScreen > Horizontal {
         height: 1fr;
     }
-    BattleScreen > Horizontal > MapWidget {
+    #map-column {
         width: 3fr;
         min-width: 40;
     }
-    BattleScreen > Horizontal > Vertical {
+    #info-column {
         width: 2fr;
-        min-width: 30;
+        min-width: 28;
     }
-    BattleScreen > Horizontal > Vertical > PlayerHUDWidget {
+    #info-column > CharacterBadgeWidget {
         height: auto;
-        max-height: 50%;
+        max-height: 40%;
     }
-    BattleScreen > Horizontal > Vertical > CombatLogWidget {
+    #info-column > EnemyPanelWidget {
+        height: auto;
+        max-height: 30%;
+    }
+    #info-column > CombatLogWidget {
         height: 1fr;
-        border: solid #30363d;
     }
     """
 
@@ -98,9 +102,11 @@ class BattleScreen(Screen):
     def compose(self) -> ComposeResult:
         yield TurnHeader(id="turn-header")
         with Horizontal():
-            yield MapWidget(id="map-widget")
-            with Vertical():
-                yield PlayerHUDWidget(id="player-hud")
+            with Vertical(id="map-column"):
+                yield MapWidget(id="map-widget")
+            with Vertical(id="info-column"):
+                yield CharacterBadgeWidget(id="character-badge")
+                yield EnemyPanelWidget(id="enemy-panel")
                 yield CombatLogWidget(id="combat-log")
         yield ActionBarWidget(id="action-bar")
 

--- a/emberblast/tui/screens/battle.py
+++ b/emberblast/tui/screens/battle.py
@@ -21,6 +21,17 @@ _KEY_TO_ACTION = {v.lower(): k for k, v in ACTION_KEYS.items()}
 class TurnHeader(Static):
     """Displays current turn number and map name."""
 
+    DEFAULT_CSS = """
+    TurnHeader {
+        dock: top;
+        height: 1;
+        background: #161b22;
+        color: #f0883e;
+        text-style: bold;
+        content-align: center middle;
+    }
+    """
+
     def __init__(self, **kwargs) -> None:
         super().__init__("", **kwargs)
         self._turn: int = 0
@@ -43,6 +54,32 @@ class TurnHeader(Static):
 
 class BattleScreen(Screen):
     """Main battle screen with classic RPG layout."""
+
+    DEFAULT_CSS = """
+    BattleScreen {
+        background: #0d1117;
+    }
+    BattleScreen > Horizontal {
+        height: 1fr;
+    }
+    BattleScreen > Horizontal > MapWidget {
+        width: 2fr;
+        min-width: 30;
+    }
+    BattleScreen > Horizontal > Vertical {
+        width: 1fr;
+        min-width: 20;
+    }
+    BattleScreen > Horizontal > Vertical > PlayerHUDWidget {
+        height: auto;
+        max-height: 8;
+        border: solid #30363d;
+    }
+    BattleScreen > Horizontal > Vertical > CombatLogWidget {
+        height: 1fr;
+        border: solid #30363d;
+    }
+    """
 
     def __init__(self, friendly_names: Optional[list] = None, **kwargs) -> None:
         super().__init__(**kwargs)

--- a/emberblast/tui/screens/battle.py
+++ b/emberblast/tui/screens/battle.py
@@ -1,0 +1,192 @@
+"""Battle screen composing map, HUD, combat log, and action bar."""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.screen import Screen
+from textual.widgets import Static
+
+from emberblast.tui.widgets.action_bar import ACTION_KEYS, ActionBarWidget
+from emberblast.tui.widgets.combat_log import CombatLogWidget
+from emberblast.tui.widgets.map_grid import MapWidget
+from emberblast.tui.widgets.player_hud import PlayerHUDWidget
+
+# Reverse lookup: key letter -> action name
+_KEY_TO_ACTION = {v.lower(): k for k, v in ACTION_KEYS.items()}
+
+
+class TurnHeader(Static):
+    """Displays current turn number and map name."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__("", **kwargs)
+        self._turn: int = 0
+        self._map_name: str = ""
+
+    def set_turn(self, turn: int) -> None:
+        self._turn = turn
+        self._refresh_text()
+
+    def set_map_name(self, name: str) -> None:
+        self._map_name = name
+        self._refresh_text()
+
+    def _refresh_text(self) -> None:
+        label = f"\u2694 TURN {self._turn}"
+        if self._map_name:
+            label += f"  {self._map_name}"
+        self.update(label)
+
+
+class BattleScreen(Screen):
+    """Main battle screen with classic RPG layout."""
+
+    def __init__(self, friendly_names: Optional[list] = None, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._questioner: Any = None
+        self._friendly_names: list = friendly_names or []
+
+        # Interaction state
+        self._mode: str = "idle"  # idle | actions | choices | confirm
+        self._available_actions: List[str] = []
+        self._choices: list = []
+        self._choice_labels: list = []
+        self._choice_index: int = 0
+        self._question_type: str = ""
+        self._confirm_message: str = ""
+
+    def compose(self) -> ComposeResult:
+        yield TurnHeader(id="turn-header")
+        with Horizontal():
+            yield MapWidget(id="map-widget")
+            with Vertical():
+                yield PlayerHUDWidget(id="player-hud")
+                yield CombatLogWidget(id="combat-log")
+        yield ActionBarWidget(id="action-bar")
+
+    def set_questioner(self, questioner: Any) -> None:
+        """Wire the questioner for resolving user input."""
+        self._questioner = questioner
+
+    def show_actions(self, actions: List[str]) -> None:
+        """Display action buttons and enable key selection."""
+        self._mode = "actions"
+        self._available_actions = list(actions)
+        try:
+            bar = self.query_one("#action-bar", ActionBarWidget)
+            bar.set_actions(actions)
+        except Exception:
+            pass
+
+    def show_choices(self, question_type: str, choices: list, labels: Optional[list] = None) -> None:
+        """Show a navigable list of choices."""
+        self._mode = "choices"
+        self._question_type = question_type
+        self._choices = list(choices)
+        self._choice_labels = list(labels) if labels else [str(c) for c in choices]
+        self._choice_index = 0
+        self._update_choice_display()
+
+    def show_confirm(self, question_type: str, message: str) -> None:
+        """Show a Y/N confirmation prompt."""
+        self._mode = "confirm"
+        self._question_type = question_type
+        self._confirm_message = message
+        try:
+            bar = self.query_one("#action-bar", ActionBarWidget)
+            bar.set_status(f"{message} [Y/N]")
+        except Exception:
+            pass
+
+    def _update_choice_display(self) -> None:
+        """Update the action bar to show current choice selection."""
+        try:
+            bar = self.query_one("#action-bar", ActionBarWidget)
+            if self._choice_labels:
+                idx = self._choice_index
+                total = len(self._choice_labels)
+                label = self._choice_labels[idx]
+                bar.set_status(f"\u25b6 {label}  ({idx + 1}/{total})  [Up/Down] Navigate  [Enter] Select  [Esc] Cancel")
+            else:
+                bar.set_status("")
+        except Exception:
+            pass
+
+    def on_key(self, event) -> None:
+        """Handle all keyboard input based on current mode."""
+        key = event.key.lower() if hasattr(event, "key") else ""
+
+        if self._mode == "actions":
+            self._handle_action_key(key)
+        elif self._mode == "choices":
+            self._handle_choice_key(key)
+        elif self._mode == "confirm":
+            self._handle_confirm_key(key)
+
+    def _handle_action_key(self, key: str) -> None:
+        """Handle key press in action selection mode."""
+        action = _KEY_TO_ACTION.get(key)
+        if action and action in self._available_actions:
+            self._mode = "idle"
+            try:
+                bar = self.query_one("#action-bar", ActionBarWidget)
+                bar.clear()
+            except Exception:
+                pass
+            if self._questioner:
+                self._questioner.resolve(action)
+
+    def _handle_choice_key(self, key: str) -> None:
+        """Handle key press in choice navigation mode."""
+        if key in ("up", "k"):
+            if self._choice_index > 0:
+                self._choice_index -= 1
+                self._update_choice_display()
+        elif key in ("down", "j"):
+            if self._choice_index < len(self._choices) - 1:
+                self._choice_index += 1
+                self._update_choice_display()
+        elif key == "enter":
+            if self._choices:
+                selected = self._choices[self._choice_index]
+                self._mode = "idle"
+                try:
+                    bar = self.query_one("#action-bar", ActionBarWidget)
+                    bar.clear()
+                except Exception:
+                    pass
+                if self._questioner:
+                    self._questioner.resolve(selected)
+        elif key == "escape":
+            self._mode = "idle"
+            try:
+                bar = self.query_one("#action-bar", ActionBarWidget)
+                bar.clear()
+            except Exception:
+                pass
+            if self._questioner:
+                self._questioner.resolve(False)
+
+    def _handle_confirm_key(self, key: str) -> None:
+        """Handle key press in Y/N confirmation mode."""
+        if key == "y":
+            self._mode = "idle"
+            try:
+                bar = self.query_one("#action-bar", ActionBarWidget)
+                bar.clear()
+            except Exception:
+                pass
+            if self._questioner:
+                self._questioner.resolve(True)
+        elif key == "n":
+            self._mode = "idle"
+            try:
+                bar = self.query_one("#action-bar", ActionBarWidget)
+                bar.clear()
+            except Exception:
+                pass
+            if self._questioner:
+                self._questioner.resolve(False)

--- a/emberblast/tui/screens/battle.py
+++ b/emberblast/tui/screens/battle.py
@@ -130,6 +130,12 @@ class BattleScreen(Screen):
         self._choices = list(choices)
         self._choice_labels = list(labels) if labels else [str(c) for c in choices]
         self._choice_index = 0
+        # Pause combat log scrolling while navigating choices
+        try:
+            log = self.query_one("#combat-log", CombatLogWidget)
+            log.pause_scroll()
+        except Exception:
+            pass
         self._update_choice_display()
 
     def show_confirm(self, question_type: str, message: str) -> None:
@@ -171,6 +177,15 @@ class BattleScreen(Screen):
         """Handle all keyboard input based on current mode."""
         key = event.key.lower() if hasattr(event, "key") else ""
 
+        # Tab cycles enemy panel selection regardless of mode
+        if key == "tab":
+            try:
+                panel = self.query_one("#enemy-panel", EnemyPanelWidget)
+                panel.cycle_enemy(1)
+            except Exception:
+                pass
+            return
+
         if self._mode == "actions":
             self._handle_action_key(key)
         elif self._mode == "choices":
@@ -210,6 +225,11 @@ class BattleScreen(Screen):
                     bar.clear()
                 except Exception:
                     pass
+                try:
+                    log = self.query_one("#combat-log", CombatLogWidget)
+                    log.resume_scroll()
+                except Exception:
+                    pass
                 # Clear movement highlights from the map
                 if hasattr(self.app, "clear_highlights"):
                     self.app.clear_highlights()
@@ -220,6 +240,11 @@ class BattleScreen(Screen):
             try:
                 bar = self.query_one("#action-bar", ActionBarWidget)
                 bar.clear()
+            except Exception:
+                pass
+            try:
+                log = self.query_one("#combat-log", CombatLogWidget)
+                log.resume_scroll()
             except Exception:
                 pass
             # Clear movement highlights from the map

--- a/emberblast/tui/screens/battle.py
+++ b/emberblast/tui/screens/battle.py
@@ -24,11 +24,12 @@ class TurnHeader(Static):
     DEFAULT_CSS = """
     TurnHeader {
         dock: top;
-        height: 1;
+        height: 3;
         background: #161b22;
         color: #f0883e;
         text-style: bold;
         content-align: center middle;
+        border: solid #f0883e;
     }
     """
 
@@ -63,17 +64,16 @@ class BattleScreen(Screen):
         height: 1fr;
     }
     BattleScreen > Horizontal > MapWidget {
+        width: 3fr;
+        min-width: 40;
+    }
+    BattleScreen > Horizontal > Vertical {
         width: 2fr;
         min-width: 30;
     }
-    BattleScreen > Horizontal > Vertical {
-        width: 1fr;
-        min-width: 20;
-    }
     BattleScreen > Horizontal > Vertical > PlayerHUDWidget {
         height: auto;
-        max-height: 14;
-        border: solid #30363d;
+        max-height: 50%;
     }
     BattleScreen > Horizontal > Vertical > CombatLogWidget {
         height: 1fr;

--- a/emberblast/tui/screens/battle.py
+++ b/emberblast/tui/screens/battle.py
@@ -72,7 +72,7 @@ class BattleScreen(Screen):
     }
     BattleScreen > Horizontal > Vertical > PlayerHUDWidget {
         height: auto;
-        max-height: 8;
+        max-height: 14;
         border: solid #30363d;
     }
     BattleScreen > Horizontal > Vertical > CombatLogWidget {
@@ -152,6 +152,16 @@ class BattleScreen(Screen):
         except Exception:
             pass
 
+        # Flash the currently selected cell when navigating movement choices
+        if self._question_type == "ask_where_to_move" and self._choices:
+            try:
+                map_w = self.query_one("#map-widget", MapWidget)
+                selected_pos = self._choices[self._choice_index]
+                map_w._flash_cells = {str(selected_pos)}
+                map_w.refresh()
+            except Exception:
+                pass
+
     def on_key(self, event) -> None:
         """Handle all keyboard input based on current mode."""
         key = event.key.lower() if hasattr(event, "key") else ""
@@ -195,6 +205,9 @@ class BattleScreen(Screen):
                     bar.clear()
                 except Exception:
                     pass
+                # Clear movement highlights from the map
+                if hasattr(self.app, "clear_highlights"):
+                    self.app.clear_highlights()
                 if self._questioner:
                     self._questioner.resolve(selected)
         elif key == "escape":
@@ -204,6 +217,9 @@ class BattleScreen(Screen):
                 bar.clear()
             except Exception:
                 pass
+            # Clear movement highlights from the map
+            if hasattr(self.app, "clear_highlights"):
+                self.app.clear_highlights()
             if self._questioner:
                 self._questioner.resolve(False)
 

--- a/emberblast/tui/screens/battle.py
+++ b/emberblast/tui/screens/battle.py
@@ -66,17 +66,18 @@ class BattleScreen(Screen):
     }
     #map-column {
         width: 3fr;
-        min-width: 50;
+        min-width: 60;
     }
     #info-column {
         width: 2fr;
-        min-width: 32;
+        min-width: 34;
     }
     #info-column > CharacterBadgeWidget {
         height: auto;
     }
     #info-column > EnemyPanelWidget {
-        height: auto;
+        height: 1fr;
+        min-height: 10;
     }
     #info-column > CombatLogWidget {
         height: 1fr;

--- a/emberblast/tui/screens/battle.py
+++ b/emberblast/tui/screens/battle.py
@@ -26,11 +26,11 @@ class TurnHeader(Static):
     TurnHeader {
         dock: top;
         height: 3;
-        background: #161b22;
+        background: #0d1117;
         color: #f0883e;
         text-style: bold;
         content-align: center middle;
-        border: solid #f0883e;
+        border: tall #f0883e;
     }
     """
 
@@ -66,22 +66,21 @@ class BattleScreen(Screen):
     }
     #map-column {
         width: 3fr;
-        min-width: 40;
+        min-width: 50;
     }
     #info-column {
         width: 2fr;
-        min-width: 28;
+        min-width: 32;
     }
     #info-column > CharacterBadgeWidget {
         height: auto;
-        max-height: 40%;
     }
     #info-column > EnemyPanelWidget {
         height: auto;
-        max-height: 30%;
     }
     #info-column > CombatLogWidget {
         height: 1fr;
+        min-height: 6;
     }
     """
 

--- a/emberblast/tui/screens/game_over.py
+++ b/emberblast/tui/screens/game_over.py
@@ -1,0 +1,55 @@
+"""Game over screen with victory banner and menu."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.screen import Screen
+from textual.widgets import Static
+
+MENU_ITEMS = ["Play Again", "Quit"]
+
+
+class GameOverScreen(Screen):
+    """Displays a victory banner and play again / quit menu."""
+
+    def __init__(self, winner_name: str = "", **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._winner_name = winner_name
+        self._menu_index: int = 0
+
+    def compose(self) -> ComposeResult:
+        banner = f"\u2728 VICTORY! \u2728\n\n{self._winner_name} has won the battle!"
+        yield Static(banner, id="victory-banner")
+        yield Static(self._build_menu_text(), id="game-over-menu")
+
+    def _build_menu_text(self) -> str:
+        lines = []
+        for i, item in enumerate(MENU_ITEMS):
+            prefix = "\u25b6 " if i == self._menu_index else "  "
+            lines.append(f"{prefix}{item}")
+        return "\n".join(lines)
+
+    def _refresh_menu(self) -> None:
+        try:
+            menu = self.query_one("#game-over-menu", Static)
+            menu.update(self._build_menu_text())
+        except Exception:
+            pass
+
+    def on_key(self, event) -> None:
+        key = event.key.lower() if hasattr(event, "key") else ""
+
+        if key in ("up", "k"):
+            if self._menu_index > 0:
+                self._menu_index -= 1
+                self._refresh_menu()
+        elif key in ("down", "j"):
+            if self._menu_index < len(MENU_ITEMS) - 1:
+                self._menu_index += 1
+                self._refresh_menu()
+        elif key == "enter":
+            selected = MENU_ITEMS[self._menu_index]
+            if selected == "Quit":
+                self.app.exit()
+            elif selected == "Play Again":
+                self.app.exit(result="play_again")

--- a/emberblast/tui/screens/setup.py
+++ b/emberblast/tui/screens/setup.py
@@ -1,0 +1,155 @@
+"""Setup screen for game creation and character creation questions."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from textual.app import ComposeResult
+from textual.screen import Screen
+from textual.widgets import Input, Static
+
+
+class SetupScreen(Screen):
+    """Multi-purpose screen handling game creation and character creation flows.
+
+    Supports list navigation for selections and text input via Textual Input widget.
+    Resolves answers through the questioner when the user completes their selection.
+    """
+
+    def __init__(self, question_type: str = "", **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._questioner: Any = None
+        self._question_type: str = question_type
+
+        # Interaction state
+        self._mode: str = "idle"  # idle | list | input
+        self._choices: list = []
+        self._choice_labels: list = []
+        self._choice_index: int = 0
+        self._prompt_text: str = ""
+        self._on_resolve: Any = None  # callback after resolve
+
+    def compose(self) -> ComposeResult:
+        yield Static("", id="setup-title")
+        yield Static("", id="setup-prompt")
+        yield Static("", id="setup-choices")
+        yield Input(placeholder="Type here...", id="setup-input")
+
+    def on_mount(self) -> None:
+        """Hide the input widget initially."""
+        try:
+            inp = self.query_one("#setup-input", Input)
+            inp.display = False
+        except Exception:
+            pass
+
+    def set_questioner(self, questioner: Any) -> None:
+        """Wire the questioner."""
+        self._questioner = questioner
+
+    def show_list(
+        self,
+        prompt: str,
+        choices: list,
+        labels: Optional[list] = None,
+    ) -> None:
+        """Display a navigable list of choices."""
+        self._mode = "list"
+        self._prompt_text = prompt
+        self._choices = list(choices)
+        self._choice_labels = list(labels) if labels else [str(c) for c in choices]
+        self._choice_index = 0
+
+        try:
+            title = self.query_one("#setup-title", Static)
+            title.update(prompt)
+        except Exception:
+            pass
+
+        try:
+            inp = self.query_one("#setup-input", Input)
+            inp.display = False
+        except Exception:
+            pass
+
+        self._refresh_choices_display()
+
+    def show_input(self, prompt: str, placeholder: str = "Type here...") -> None:
+        """Display a text input for the user."""
+        self._mode = "input"
+        self._prompt_text = prompt
+
+        try:
+            title = self.query_one("#setup-title", Static)
+            title.update(prompt)
+        except Exception:
+            pass
+
+        try:
+            choices_widget = self.query_one("#setup-choices", Static)
+            choices_widget.update("")
+        except Exception:
+            pass
+
+        try:
+            inp = self.query_one("#setup-input", Input)
+            inp.display = True
+            inp.value = ""
+            inp.placeholder = placeholder
+            inp.focus()
+        except Exception:
+            pass
+
+    def _refresh_choices_display(self) -> None:
+        """Update the choices display."""
+        try:
+            choices_widget = self.query_one("#setup-choices", Static)
+            lines = []
+            for i, label in enumerate(self._choice_labels):
+                prefix = "\u25b6 " if i == self._choice_index else "  "
+                lines.append(f"{prefix}{label}")
+            choices_widget.update("\n".join(lines))
+        except Exception:
+            pass
+
+    def on_key(self, event) -> None:
+        """Handle keyboard input for list navigation."""
+        key = event.key.lower() if hasattr(event, "key") else ""
+
+        if self._mode == "list":
+            self._handle_list_key(key)
+
+    def _handle_list_key(self, key: str) -> None:
+        """Navigate and select from the list."""
+        if key in ("up", "k"):
+            if self._choice_index > 0:
+                self._choice_index -= 1
+                self._refresh_choices_display()
+        elif key in ("down", "j"):
+            if self._choice_index < len(self._choices) - 1:
+                self._choice_index += 1
+                self._refresh_choices_display()
+        elif key == "enter":
+            if self._choices:
+                selected = self._choices[self._choice_index]
+                self._mode = "idle"
+                if self._questioner:
+                    self._questioner.resolve(selected)
+        elif key == "escape":
+            self._mode = "idle"
+            if self._questioner:
+                self._questioner.resolve(False)
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Handle text input submission."""
+        if self._mode == "input":
+            value = event.value.strip()
+            if value:
+                self._mode = "idle"
+                try:
+                    inp = self.query_one("#setup-input", Input)
+                    inp.display = False
+                except Exception:
+                    pass
+                if self._questioner:
+                    self._questioner.resolve(value)

--- a/emberblast/tui/screens/title.py
+++ b/emberblast/tui/screens/title.py
@@ -1,0 +1,76 @@
+"""Title screen with ASCII logo and main menu."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from textual.app import ComposeResult
+from textual.screen import Screen
+from textual.widgets import Static
+
+LOGO = r"""
+ ______          _               _     _           _
+|  ____|        | |             | |   | |         | |
+| |__   _ __ ___ | |__   ___ _ __| |__ | | __ _ ___| |_
+|  __| | '_ ` _ \| '_ \ / _ \ '__| '_ \| |/ _` / __| __|
+| |____| | | | | | |_) |  __/ |  | |_) | | (_| \__ \ |_
+|______|_| |_| |_|_.__/ \___|_|  |_.__/|_|\__,_|___/\__|
+"""
+
+MENU_ITEMS = ["New Game", "Continue", "Quit"]
+
+_MENU_RESULT = {
+    "New Game": "new",
+    "Continue": "continue",
+    "Quit": "quit",
+}
+
+
+class TitleScreen(Screen):
+    """Title screen with ASCII logo and navigable menu."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._questioner: Any = None
+        self._menu_index: int = 0
+
+    def compose(self) -> ComposeResult:
+        yield Static(LOGO, id="title-logo")
+        yield Static(self._build_menu_text(), id="title-menu")
+
+    def set_questioner(self, questioner: Any) -> None:
+        """Wire the questioner."""
+        self._questioner = questioner
+
+    def _build_menu_text(self) -> str:
+        lines = []
+        for i, item in enumerate(MENU_ITEMS):
+            prefix = "\u25b6 " if i == self._menu_index else "  "
+            lines.append(f"{prefix}{item}")
+        return "\n".join(lines)
+
+    def _refresh_menu(self) -> None:
+        try:
+            menu = self.query_one("#title-menu", Static)
+            menu.update(self._build_menu_text())
+        except Exception:
+            pass
+
+    def on_key(self, event) -> None:
+        key = event.key.lower() if hasattr(event, "key") else ""
+
+        if key in ("up", "k"):
+            if self._menu_index > 0:
+                self._menu_index -= 1
+                self._refresh_menu()
+        elif key in ("down", "j"):
+            if self._menu_index < len(MENU_ITEMS) - 1:
+                self._menu_index += 1
+                self._refresh_menu()
+        elif key == "enter":
+            selected = MENU_ITEMS[self._menu_index]
+            result = _MENU_RESULT[selected]
+            if result == "quit":
+                self.app.exit()
+            elif self._questioner:
+                self._questioner.resolve(result)

--- a/emberblast/tui/styles.py
+++ b/emberblast/tui/styles.py
@@ -31,6 +31,19 @@ LOG_COLORS: dict[str, str] = {
     "death": "#f85149",
     "xp": "#e3b341",
     "item": "#3fb950",
+    "turn": "#f0883e",
+    "skill": "#d2a8ff",
+    "dice": "#e3b341",
+    "critical": "#ff7b72",
+    "victory": "#3fb950",
+    "side_effect": "#d2a8ff",
+    "trap": "#f85149",
+    "info": "#8b949e",
+    "miss": "#6e7681",
+    "warning": "#e3b341",
+    "level_up": "#3fb950",
+    "action": "#58a6ff",
+    "stats": "#8b949e",
 }
 
 ACTION_COLORS: dict[str, str] = {

--- a/emberblast/tui/styles.py
+++ b/emberblast/tui/styles.py
@@ -1,0 +1,63 @@
+"""Shared visual constants for the Textual TUI."""
+
+TERRAIN_SYMBOLS: dict[str, str] = {
+    "plains": "░░",
+    "wall": "██",
+    "water": "~~",
+    "mountain": "^^",
+    "forest": "**",
+}
+
+TERRAIN_COLORS: dict[str, str] = {
+    "plains": "#484f58",
+    "wall": "#6e7681",
+    "water": "#58a6ff",
+    "mountain": "#f0883e",
+    "forest": "#3fb950",
+}
+
+TEAM_COLORS: dict[str, dict[str, str]] = {
+    "friendly": {"fg": "#3fb950", "bg": "#1a6334"},
+    "enemy": {"fg": "#f85149", "bg": "#6e2d1a"},
+}
+
+LOG_COLORS: dict[str, str] = {
+    "damage": "#f85149",
+    "heal": "#3fb950",
+    "narration": "#f0883e",
+    "move": "#58a6ff",
+    "system": "#8b949e",
+    "mana": "#d2a8ff",
+    "death": "#f85149",
+    "xp": "#e3b341",
+    "item": "#3fb950",
+}
+
+ACTION_COLORS: dict[str, str] = {
+    "move": "#58a6ff",
+    "attack": "#f85149",
+    "skill": "#d2a8ff",
+    "defend": "#3fb950",
+    "item": "#f0883e",
+    "hide": "#8b949e",
+    "search": "#e3b341",
+    "equip": "#58a6ff",
+    "drop": "#f85149",
+    "check": "#8b949e",
+    "pass": "#6e7681",
+}
+
+BG_COLOR = "#0d1117"
+PANEL_BG = "#161b22"
+BORDER_COLOR = "#30363d"
+BOT_TURN_DELAY = 0.5
+
+
+def get_player_token(name: str, job_name: str) -> str:
+    """Return a 2-character uppercase token from the player name and job."""
+    return (name[0] + job_name[0]).upper()
+
+
+def get_terrain_cell(terrain_type: str) -> str:
+    """Return the 2-char symbol for a terrain type, defaulting to plains."""
+    return TERRAIN_SYMBOLS.get(terrain_type, TERRAIN_SYMBOLS["plains"])

--- a/emberblast/tui/widgets/action_bar.py
+++ b/emberblast/tui/widgets/action_bar.py
@@ -26,12 +26,12 @@ ACTION_KEYS: Dict[str, str] = {
 
 
 class ActionBarWidget(Widget):
-    """Displays available actions as keybinding buttons."""
+    """Displays available actions as styled bordered buttons."""
 
     DEFAULT_CSS = """
     ActionBarWidget {
         dock: bottom;
-        height: 3;
+        height: 5;
         background: #161b22;
         border-top: solid #30363d;
         content-align: center middle;
@@ -60,23 +60,42 @@ class ActionBarWidget(Widget):
         self.refresh()
 
     def _build_bar_text(self) -> Text:
-        """Build a Rich Text object for the action bar."""
+        """Build a Rich Text object for the action bar with bordered buttons."""
         result = Text()
 
+        if self._status and not self._actions:
+            result.append("\n ")
+            result.append(self._status, style=Style(italic=True, color="#8b949e"))
+            return result
+
         if self._actions:
-            for i, action in enumerate(self._actions):
+            # Top border of buttons
+            top_line = Text(" ")
+            mid_line = Text(" ")
+            bot_line = Text(" ")
+
+            for action in self._actions:
                 key = ACTION_KEYS.get(action, action[0].upper())
                 color = ACTION_COLORS.get(action, "#8b949e")
+                label = f"[{key}]{action[1:]}"
+                width = len(label) + 2  # padding inside box
+                border_style = Style(color=color)
 
-                if i > 0:
-                    result.append("  ")
+                top_line.append("\u250c" + "\u2500" * width + "\u2510 ", style=border_style)
+                mid_line.append("\u2502", style=border_style)
+                mid_line.append(f" [{key}]", style=Style(bold=True, color=color))
+                mid_line.append(f"{action[1:]} ", style=Style(color=color))
+                mid_line.append("\u2502 ", style=border_style)
+                bot_line.append("\u2514" + "\u2500" * width + "\u2518 ", style=border_style)
 
-                result.append(f"[{key}]", style=Style(bold=True, color=color))
-                result.append(f" {action.capitalize()}", style=Style(color=color))
+            result.append_text(top_line)
+            result.append("\n")
+            result.append_text(mid_line)
+            result.append("\n")
+            result.append_text(bot_line)
 
-        if self._status:
-            if self._actions:
-                result.append("  ")
+        if self._status and self._actions:
+            result.append("\n ")
             result.append(self._status, style=Style(dim=True, italic=True))
 
         return result

--- a/emberblast/tui/widgets/action_bar.py
+++ b/emberblast/tui/widgets/action_bar.py
@@ -32,8 +32,8 @@ class ActionBarWidget(Widget):
     ActionBarWidget {
         dock: bottom;
         height: 5;
-        background: #161b22;
-        border-top: solid #30363d;
+        background: #0d1117;
+        border-top: tall #30363d;
         content-align: center middle;
     }
     """

--- a/emberblast/tui/widgets/action_bar.py
+++ b/emberblast/tui/widgets/action_bar.py
@@ -1,0 +1,76 @@
+"""Action bar widget for the Textual TUI."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from rich.style import Style
+from rich.text import Text
+from textual.widget import Widget
+
+from emberblast.tui.styles import ACTION_COLORS
+
+ACTION_KEYS: Dict[str, str] = {
+    "move": "M",
+    "attack": "A",
+    "skill": "S",
+    "defend": "D",
+    "item": "I",
+    "hide": "H",
+    "search": "R",
+    "equip": "E",
+    "drop": "X",
+    "check": "C",
+    "pass": "P",
+}
+
+
+class ActionBarWidget(Widget):
+    """Displays available actions as keybinding buttons."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._actions: List[str] = []
+        self._status: str = ""
+
+    def set_actions(self, actions: List[str]) -> None:
+        """Set the available actions and refresh."""
+        self._actions = list(actions)
+        self.refresh()
+
+    def set_status(self, text: str) -> None:
+        """Set a status message (shown when no actions or alongside them)."""
+        self._status = text
+        self.refresh()
+
+    def clear(self) -> None:
+        """Reset actions and status."""
+        self._actions = []
+        self._status = ""
+        self.refresh()
+
+    def _build_bar_text(self) -> Text:
+        """Build a Rich Text object for the action bar."""
+        result = Text()
+
+        if self._actions:
+            for i, action in enumerate(self._actions):
+                key = ACTION_KEYS.get(action, action[0].upper())
+                color = ACTION_COLORS.get(action, "#8b949e")
+
+                if i > 0:
+                    result.append("  ")
+
+                result.append(f"[{key}]", style=Style(bold=True, color=color))
+                result.append(f" {action.capitalize()}", style=Style(color=color))
+
+        if self._status:
+            if self._actions:
+                result.append("  ")
+            result.append(self._status, style=Style(dim=True, italic=True))
+
+        return result
+
+    def render(self) -> Text:
+        """Render the widget content."""
+        return self._build_bar_text()

--- a/emberblast/tui/widgets/action_bar.py
+++ b/emberblast/tui/widgets/action_bar.py
@@ -28,6 +28,16 @@ ACTION_KEYS: Dict[str, str] = {
 class ActionBarWidget(Widget):
     """Displays available actions as keybinding buttons."""
 
+    DEFAULT_CSS = """
+    ActionBarWidget {
+        dock: bottom;
+        height: 3;
+        background: #161b22;
+        border-top: solid #30363d;
+        content-align: center middle;
+    }
+    """
+
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
         self._actions: List[str] = []

--- a/emberblast/tui/widgets/character_badge.py
+++ b/emberblast/tui/widgets/character_badge.py
@@ -1,0 +1,154 @@
+"""Character badge widget — always-visible controlled player info."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from rich.style import Style
+from rich.text import Text
+from textual.widget import Widget
+
+BAR_WIDTH = 20
+FILLED = "\u2588"  # █
+EMPTY = "\u2591"  # ░
+
+
+def _bar_color(ratio: float) -> str:
+    """Return a hex color based on the health/mana ratio."""
+    if ratio > 0.50:
+        return "#3fb950"  # green
+    if ratio > 0.25:
+        return "#e3b341"  # yellow
+    return "#f85149"  # red
+
+
+def _build_bar(current: int, maximum: int, label: str, bar_width: int = BAR_WIDTH) -> Text:
+    """Build a colored bar with label and numeric values."""
+    ratio = current / maximum if maximum > 0 else 0
+    filled_count = round(ratio * bar_width)
+    empty_count = bar_width - filled_count
+    color = _bar_color(ratio)
+
+    bar = Text()
+    bar.append(f" {label}: ", style=Style(bold=True, color="#8b949e"))
+    bar.append(FILLED * filled_count, style=Style(color=color))
+    bar.append(EMPTY * empty_count, style=Style(color="#30363d"))
+    bar.append(f" {current}/{maximum}", style=Style(dim=True))
+    return bar
+
+
+class CharacterBadgeWidget(Widget):
+    """Always-visible panel showing the controlled player's full stats."""
+
+    DEFAULT_CSS = """
+    CharacterBadgeWidget {
+        background: #161b22;
+        padding: 1;
+        border: solid #3fb950;
+        height: auto;
+        max-height: 18;
+    }
+    """
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._player: Optional[object] = None
+
+    def update_player(self, player: object) -> None:
+        """Update the displayed player and refresh."""
+        self._player = player
+        self.refresh()
+
+    def _build_badge_text(self) -> Text:
+        """Build a Rich Text object for the character badge."""
+        result = Text()
+
+        if self._player is None:
+            result.append(" No player data", style=Style(dim=True))
+            return result
+
+        p = self._player
+
+        job_name = p.job.name if hasattr(p.job, "name") else str(p.job)
+        race_name = p.race.name if hasattr(p.race, "name") else str(p.race)
+
+        # Header: name + race
+        result.append(" \u2694 ", style=Style(color="#f0883e"))
+        result.append(f"{p.name}", style=Style(bold=True, color="#58a6ff"))
+        result.append(f"  {race_name}", style=Style(color="#8b949e"))
+        result.append("\n")
+
+        # Job + Level
+        result.append(f"   {job_name}", style=Style(color="#d2a8ff"))
+        result.append(f"  Lv.{p.level}", style=Style(color="#f0883e", bold=True))
+        result.append("\n")
+
+        # Separator
+        result.append(" " + "\u2500" * 24 + "\n", style=Style(color="#30363d"))
+
+        # HP bar
+        hp_bar = _build_bar(p.life, p.health_points, "HP")
+        result.append_text(hp_bar)
+        result.append("\n")
+
+        # MP bar
+        mp_bar = _build_bar(p.mana, p.magic_points, "MP")
+        result.append_text(mp_bar)
+        result.append("\n")
+
+        # Separator
+        result.append(" " + "\u2500" * 24 + "\n", style=Style(color="#30363d"))
+
+        # Stats in 2 columns
+        result.append("  STR ", style=Style(color="#8b949e"))
+        result.append(f"{p.strength:<4}", style=Style(bold=True, color="#f85149"))
+        result.append("INT ", style=Style(color="#8b949e"))
+        result.append(f"{p.intelligence:<4}", style=Style(bold=True, color="#d2a8ff"))
+        result.append("ACC ", style=Style(color="#8b949e"))
+        result.append(f"{p.accuracy}", style=Style(bold=True, color="#e3b341"))
+        result.append("\n")
+
+        result.append("  ARM ", style=Style(color="#8b949e"))
+        result.append(f"{p.armour:<4}", style=Style(bold=True, color="#58a6ff"))
+        result.append("RES ", style=Style(color="#8b949e"))
+        result.append(f"{p.magic_resist:<4}", style=Style(bold=True, color="#d2a8ff"))
+        result.append("SPD ", style=Style(color="#8b949e"))
+        result.append(f"{p.move_speed}", style=Style(bold=True, color="#3fb950"))
+        result.append("\n")
+
+        result.append("  WILL ", style=Style(color="#8b949e"))
+        result.append(f"{p.will}", style=Style(bold=True, color="#e3b341"))
+
+        # Position
+        if hasattr(p, "position") and p.position:
+            pos = p.position
+            if isinstance(pos, list) and len(pos) == 2:
+                from emberblast.utils import convert_number_to_letter
+
+                pos_str = f"{convert_number_to_letter(pos[0])}{pos[1]}"
+            else:
+                pos_str = str(pos)
+            result.append("   Pos: ", style=Style(color="#8b949e"))
+            result.append(pos_str, style=Style(bold=True, color="#58a6ff"))
+
+        result.append("\n")
+
+        # Active side effects
+        if hasattr(p, "side_effects") and p.side_effects:
+            result.append(" " + "\u2500" * 24 + "\n", style=Style(color="#30363d"))
+            result.append(" Effects:\n", style=Style(color="#8b949e"))
+            for se in p.side_effects:
+                se_name = se.name if hasattr(se, "name") else str(se)
+                se_type = getattr(se, "effect_type", "buff")
+                icon = "\u25b2" if se_type == "buff" else "\u25bc"
+                color = "#3fb950" if se_type == "buff" else "#f85149"
+                result.append(f"  {icon} {se_name}", style=Style(color=color))
+                if hasattr(se, "duration"):
+                    result.append(f" ({se.duration}t)", style=Style(dim=True))
+                result.append("\n")
+
+        return result
+
+    def render(self) -> Text:
+        """Render the widget content."""
+        return self._build_badge_text()

--- a/emberblast/tui/widgets/character_badge.py
+++ b/emberblast/tui/widgets/character_badge.py
@@ -8,32 +8,30 @@ from rich.style import Style
 from rich.text import Text
 from textual.widget import Widget
 
-BAR_WIDTH = 20
+BAR_WIDTH = 16
 FILLED = "\u2588"  # █
 EMPTY = "\u2591"  # ░
 
 
 def _bar_color(ratio: float) -> str:
-    """Return a hex color based on the health/mana ratio."""
     if ratio > 0.50:
-        return "#3fb950"  # green
+        return "#3fb950"
     if ratio > 0.25:
-        return "#e3b341"  # yellow
-    return "#f85149"  # red
+        return "#e3b341"
+    return "#f85149"
 
 
-def _build_bar(current: int, maximum: int, label: str, bar_width: int = BAR_WIDTH) -> Text:
-    """Build a colored bar with label and numeric values."""
+def _build_bar(current: int, maximum: int, label: str, color_override: str = "") -> Text:
     ratio = current / maximum if maximum > 0 else 0
-    filled_count = round(ratio * bar_width)
-    empty_count = bar_width - filled_count
-    color = _bar_color(ratio)
+    filled_count = round(ratio * BAR_WIDTH)
+    empty_count = BAR_WIDTH - filled_count
+    color = color_override or _bar_color(ratio)
 
     bar = Text()
-    bar.append(f" {label}: ", style=Style(bold=True, color="#8b949e"))
+    bar.append(f" {label} ", style=Style(bold=True, color="#8b949e"))
     bar.append(FILLED * filled_count, style=Style(color=color))
-    bar.append(EMPTY * empty_count, style=Style(color="#30363d"))
-    bar.append(f" {current}/{maximum}", style=Style(dim=True))
+    bar.append(EMPTY * empty_count, style=Style(color="#21262d"))
+    bar.append(f" {current}/{maximum}", style=Style(color="#6e7681"))
     return bar
 
 
@@ -42,11 +40,11 @@ class CharacterBadgeWidget(Widget):
 
     DEFAULT_CSS = """
     CharacterBadgeWidget {
-        background: #161b22;
-        padding: 1;
-        border: solid #3fb950;
+        background: #0d1117;
+        padding: 0 1;
+        border: tall #3fb950;
         height: auto;
-        max-height: 18;
+        min-height: 14;
     }
     """
 
@@ -55,69 +53,31 @@ class CharacterBadgeWidget(Widget):
         self._player: Optional[object] = None
 
     def update_player(self, player: object) -> None:
-        """Update the displayed player and refresh."""
         self._player = player
         self.refresh()
 
     def _build_badge_text(self) -> Text:
-        """Build a Rich Text object for the character badge."""
         result = Text()
 
         if self._player is None:
-            result.append(" No player data", style=Style(dim=True))
+            result.append(" Awaiting hero...", style=Style(dim=True))
             return result
 
         p = self._player
-
         job_name = p.job.name if hasattr(p.job, "name") else str(p.job)
         race_name = p.race.name if hasattr(p.race, "name") else str(p.race)
 
-        # Header: name + race
-        result.append(" \u2694 ", style=Style(color="#f0883e"))
+        # ── Header ──
+        result.append("\n")
+        result.append("  \u2694 ", style=Style(color="#f0883e", bold=True))
         result.append(f"{p.name}", style=Style(bold=True, color="#58a6ff"))
-        result.append(f"  {race_name}", style=Style(color="#8b949e"))
-        result.append("\n")
+        result.append(f"  the {race_name} {job_name}\n", style=Style(color="#8b949e"))
 
-        # Job + Level
-        result.append(f"   {job_name}", style=Style(color="#d2a8ff"))
-        result.append(f"  Lv.{p.level}", style=Style(color="#f0883e", bold=True))
-        result.append("\n")
-
-        # Separator
-        result.append(" " + "\u2500" * 24 + "\n", style=Style(color="#30363d"))
-
-        # HP bar
-        hp_bar = _build_bar(p.life, p.health_points, "HP")
-        result.append_text(hp_bar)
-        result.append("\n")
-
-        # MP bar
-        mp_bar = _build_bar(p.mana, p.magic_points, "MP")
-        result.append_text(mp_bar)
-        result.append("\n")
-
-        # Separator
-        result.append(" " + "\u2500" * 24 + "\n", style=Style(color="#30363d"))
-
-        # Stats in 2 columns
-        result.append("  STR ", style=Style(color="#8b949e"))
-        result.append(f"{p.strength:<4}", style=Style(bold=True, color="#f85149"))
-        result.append("INT ", style=Style(color="#8b949e"))
-        result.append(f"{p.intelligence:<4}", style=Style(bold=True, color="#d2a8ff"))
-        result.append("ACC ", style=Style(color="#8b949e"))
-        result.append(f"{p.accuracy}", style=Style(bold=True, color="#e3b341"))
-        result.append("\n")
-
-        result.append("  ARM ", style=Style(color="#8b949e"))
-        result.append(f"{p.armour:<4}", style=Style(bold=True, color="#58a6ff"))
-        result.append("RES ", style=Style(color="#8b949e"))
-        result.append(f"{p.magic_resist:<4}", style=Style(bold=True, color="#d2a8ff"))
-        result.append("SPD ", style=Style(color="#8b949e"))
-        result.append(f"{p.move_speed}", style=Style(bold=True, color="#3fb950"))
-        result.append("\n")
-
-        result.append("  WILL ", style=Style(color="#8b949e"))
-        result.append(f"{p.will}", style=Style(bold=True, color="#e3b341"))
+        # Level + XP
+        result.append("  Lv.", style=Style(color="#8b949e"))
+        result.append(f"{p.level}", style=Style(bold=True, color="#f0883e"))
+        xp = getattr(p, "experience", 0)
+        result.append(f"  XP: {xp}/100", style=Style(color="#e3b341"))
 
         # Position
         if hasattr(p, "position") and p.position:
@@ -128,15 +88,64 @@ class CharacterBadgeWidget(Widget):
                 pos_str = f"{convert_number_to_letter(pos[0])}{pos[1]}"
             else:
                 pos_str = str(pos)
-            result.append("   Pos: ", style=Style(color="#8b949e"))
-            result.append(pos_str, style=Style(bold=True, color="#58a6ff"))
-
+            result.append(f"  \u25c8 {pos_str}", style=Style(color="#58a6ff"))
         result.append("\n")
 
-        # Active side effects
+        # ── Bars ──
+        result.append(" \u2500" * 15 + "\n", style=Style(color="#21262d"))
+
+        hp_bar = _build_bar(p.life, p.health_points, "HP")
+        result.append_text(hp_bar)
+        result.append("\n")
+
+        mp_bar = _build_bar(p.mana, p.magic_points, "MP")
+        result.append_text(mp_bar)
+        result.append("\n")
+
+        # XP bar
+        xp_bar = _build_bar(xp, 100, "XP", color_override="#e3b341")
+        result.append_text(xp_bar)
+        result.append("\n")
+
+        # ── Stats ──
+        result.append(" \u2500" * 15 + "\n", style=Style(color="#21262d"))
+
+        stats = [
+            ("STR", p.strength, "#f85149"),
+            ("INT", p.intelligence, "#d2a8ff"),
+            ("ACC", p.accuracy, "#e3b341"),
+            ("ARM", p.armour, "#58a6ff"),
+            ("RES", p.magic_resist, "#d2a8ff"),
+            ("SPD", p.move_speed, "#3fb950"),
+            ("WIL", p.will, "#f0883e"),
+        ]
+        for i, (name, val, color) in enumerate(stats):
+            if i % 4 == 0:
+                result.append("  ")
+            result.append(f"{name}", style=Style(color="#6e7681"))
+            result.append(f"{val:<3} ", style=Style(bold=True, color=color))
+            if i % 4 == 3:
+                result.append("\n")
+        if len(stats) % 4 != 0:
+            result.append("\n")
+
+        # ── Equipment summary ──
+        if hasattr(p, "equipment") and p.equipment:
+            eq = p.equipment
+            slots = []
+            for slot in ("weapon", "armor", "helmet", "shield", "accessory"):
+                item = getattr(eq, slot, None)
+                if item and hasattr(item, "name"):
+                    slots.append((slot[:3].upper(), item.name))
+            if slots:
+                result.append(" \u2500" * 15 + "\n", style=Style(color="#21262d"))
+                for abbr, item_name in slots:
+                    result.append(f"  {abbr} ", style=Style(color="#6e7681"))
+                    result.append(f"{item_name}\n", style=Style(color="#3fb950"))
+
+        # ── Side effects ──
         if hasattr(p, "side_effects") and p.side_effects:
-            result.append(" " + "\u2500" * 24 + "\n", style=Style(color="#30363d"))
-            result.append(" Effects:\n", style=Style(color="#8b949e"))
+            result.append(" \u2500" * 15 + "\n", style=Style(color="#21262d"))
             for se in p.side_effects:
                 se_name = se.name if hasattr(se, "name") else str(se)
                 se_type = getattr(se, "effect_type", "buff")
@@ -144,11 +153,10 @@ class CharacterBadgeWidget(Widget):
                 color = "#3fb950" if se_type == "buff" else "#f85149"
                 result.append(f"  {icon} {se_name}", style=Style(color=color))
                 if hasattr(se, "duration"):
-                    result.append(f" ({se.duration}t)", style=Style(dim=True))
+                    result.append(f" ({se.duration}t)", style=Style(color="#6e7681"))
                 result.append("\n")
 
         return result
 
     def render(self) -> Text:
-        """Render the widget content."""
         return self._build_badge_text()

--- a/emberblast/tui/widgets/character_badge.py
+++ b/emberblast/tui/widgets/character_badge.py
@@ -73,13 +73,11 @@ class CharacterBadgeWidget(Widget):
         result.append(f"{p.name}", style=Style(bold=True, color="#58a6ff"))
         result.append(f"  the {race_name} {job_name}\n", style=Style(color="#8b949e"))
 
-        # Level + XP
+        # Level + XP + Position
         result.append("  Lv.", style=Style(color="#8b949e"))
         result.append(f"{p.level}", style=Style(bold=True, color="#f0883e"))
         xp = getattr(p, "experience", 0)
         result.append(f"  XP: {xp}/100", style=Style(color="#e3b341"))
-
-        # Position
         if hasattr(p, "position") and p.position:
             pos = p.position
             if isinstance(pos, list) and len(pos) == 2:
@@ -102,32 +100,37 @@ class CharacterBadgeWidget(Widget):
         result.append_text(mp_bar)
         result.append("\n")
 
-        # XP bar
         xp_bar = _build_bar(xp, 100, "XP", color_override="#e3b341")
         result.append_text(xp_bar)
         result.append("\n")
 
-        # ── Stats ──
+        # ── Stats — 2 rows, well-spaced ──
         result.append(" \u2500" * 15 + "\n", style=Style(color="#21262d"))
 
-        stats = [
+        # Row 1: STR  INT  ACC  ARM
+        row1 = [
             ("STR", p.strength, "#f85149"),
             ("INT", p.intelligence, "#d2a8ff"),
             ("ACC", p.accuracy, "#e3b341"),
             ("ARM", p.armour, "#58a6ff"),
+        ]
+        result.append("  ")
+        for name, val, color in row1:
+            result.append(f"{name} ", style=Style(color="#6e7681"))
+            result.append(f"{val:<4}", style=Style(bold=True, color=color))
+        result.append("\n")
+
+        # Row 2: RES  SPD  WIL
+        row2 = [
             ("RES", p.magic_resist, "#d2a8ff"),
             ("SPD", p.move_speed, "#3fb950"),
             ("WIL", p.will, "#f0883e"),
         ]
-        for i, (name, val, color) in enumerate(stats):
-            if i % 4 == 0:
-                result.append("  ")
-            result.append(f"{name}", style=Style(color="#6e7681"))
-            result.append(f"{val:<3} ", style=Style(bold=True, color=color))
-            if i % 4 == 3:
-                result.append("\n")
-        if len(stats) % 4 != 0:
-            result.append("\n")
+        result.append("  ")
+        for name, val, color in row2:
+            result.append(f"{name} ", style=Style(color="#6e7681"))
+            result.append(f"{val:<4}", style=Style(bold=True, color=color))
+        result.append("\n")
 
         # ── Equipment summary ──
         if hasattr(p, "equipment") and p.equipment:

--- a/emberblast/tui/widgets/combat_log.py
+++ b/emberblast/tui/widgets/combat_log.py
@@ -13,6 +13,10 @@ from emberblast.tui.styles import LOG_COLORS
 
 DEFAULT_MAX_ENTRIES = 100
 
+# Categories that get special formatting
+_SEPARATOR_CATEGORIES = {"system"}
+_BOLD_CATEGORIES = {"turn", "victory", "death", "level_up", "critical"}
+
 
 class CombatLogWidget(Widget):
     """Scrollable, color-coded combat log."""
@@ -28,10 +32,15 @@ class CombatLogWidget(Widget):
     def __init__(self, max_entries: int = DEFAULT_MAX_ENTRIES, **kwargs) -> None:
         super().__init__(**kwargs)
         self._entries: deque[Tuple[str, str]] = deque(maxlen=max_entries)
+        self._current_turn: int = 0
+
+    def set_turn(self, turn: int) -> None:
+        """Track the current turn number for log prefixes."""
+        self._current_turn = turn
 
     def add_entry(self, message: str, category: str = "system") -> None:
         """Append a log entry and refresh."""
-        self._entries.append((message, category))
+        self._entries.append((message, category, self._current_turn))
         self.refresh()
 
     def clear_log(self) -> None:
@@ -41,13 +50,33 @@ class CombatLogWidget(Widget):
 
     def _build_log_text(self) -> Text:
         """Build a Rich Text object for the log display."""
-        if not self._entries:
-            return Text("No entries yet")
-
         result = Text()
-        for message, category in self._entries:
+        # Header
+        result.append("COMBAT LOG\n", style=Style(bold=True, color="#f0883e"))
+        result.append("─" * 30 + "\n", style=Style(color="#30363d"))
+
+        if not self._entries:
+            result.append("Awaiting battle...", style=Style(dim=True))
+            return result
+
+        for entry in self._entries:
+            message, category = entry[0], entry[1]
+            turn = entry[2] if len(entry) > 2 else 0
             color = LOG_COLORS.get(category, LOG_COLORS["system"])
-            style = Style(color=color, italic=(category == "narration"))
+
+            # Separator lines stay plain
+            if message == "---":
+                result.append("─" * 30 + "\n", style=Style(color="#30363d"))
+                continue
+
+            bold = category in _BOLD_CATEGORIES
+            italic = category == "narration"
+            style = Style(color=color, bold=bold, italic=italic)
+
+            # Add turn prefix for combat events (not system/separator)
+            if turn > 0 and category not in _SEPARATOR_CATEGORIES and category != "turn":
+                result.append(f"[T{turn}] ", style=Style(color="#6e7681", dim=True))
+
             result.append(f"{message}\n", style=style)
 
         return result

--- a/emberblast/tui/widgets/combat_log.py
+++ b/emberblast/tui/widgets/combat_log.py
@@ -1,0 +1,49 @@
+"""Combat log widget for the Textual TUI."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Tuple
+
+from rich.style import Style
+from rich.text import Text
+from textual.widget import Widget
+
+from emberblast.tui.styles import LOG_COLORS
+
+DEFAULT_MAX_ENTRIES = 100
+
+
+class CombatLogWidget(Widget):
+    """Scrollable, color-coded combat log."""
+
+    def __init__(self, max_entries: int = DEFAULT_MAX_ENTRIES, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._entries: deque[Tuple[str, str]] = deque(maxlen=max_entries)
+
+    def add_entry(self, message: str, category: str = "system") -> None:
+        """Append a log entry and refresh."""
+        self._entries.append((message, category))
+        self.refresh()
+
+    def clear_log(self) -> None:
+        """Remove all log entries."""
+        self._entries.clear()
+        self.refresh()
+
+    def _build_log_text(self) -> Text:
+        """Build a Rich Text object for the log display."""
+        if not self._entries:
+            return Text("No entries yet")
+
+        result = Text()
+        for message, category in self._entries:
+            color = LOG_COLORS.get(category, LOG_COLORS["system"])
+            style = Style(color=color, italic=(category == "narration"))
+            result.append(f"{message}\n", style=style)
+
+        return result
+
+    def render(self) -> Text:
+        """Render the widget content."""
+        return self._build_log_text()

--- a/emberblast/tui/widgets/combat_log.py
+++ b/emberblast/tui/widgets/combat_log.py
@@ -11,6 +11,27 @@ from emberblast.tui.styles import LOG_COLORS
 # Categories that get special formatting
 _BOLD_CATEGORIES = {"turn", "victory", "death", "level_up", "critical"}
 
+# Category-specific icons
+_CATEGORY_ICONS = {
+    "damage": "\u2694",
+    "heal": "\u271a",
+    "move": "\u2192",
+    "skill": "\u2726",
+    "death": "\u2620",
+    "victory": "\u265b",
+    "narration": "\u275d",
+    "item": "\u25c6",
+    "level_up": "\u25b2",
+    "xp": "\u2605",
+    "dice": "\u2684",
+    "critical": "\u26a1",
+    "side_effect": "\u223c",
+    "trap": "\u26a0",
+    "miss": "\u00d7",
+    "warning": "\u26a0",
+    "stats": "\u25a3",
+}
+
 
 class CombatLogWidget(RichLog):
     """Scrollable, color-coded combat log using Textual's RichLog for real scrolling."""
@@ -33,9 +54,10 @@ class CombatLogWidget(RichLog):
         if not self._initialized:
             self._initialized = True
             header = Text()
+            header.append(" \u2694 ", style=Style(color="#f0883e"))
             header.append("COMBAT LOG", style=Style(bold=True, color="#f0883e"))
             self.write(header)
-            sep = Text("─" * 40, style=Style(color="#30363d"))
+            sep = Text("\u2500" * 40, style=Style(color="#30363d"))
             self.write(sep)
 
     def set_turn(self, turn: int) -> None:
@@ -48,8 +70,17 @@ class CombatLogWidget(RichLog):
 
         # Separator lines
         if message == "---":
-            sep = Text("─" * 40, style=Style(color="#30363d"))
+            sep = Text("\u2500" * 40, style=Style(color="#30363d"))
             self.write(sep)
+            return
+
+        # Turn start gets special banner treatment
+        if category == "turn" and "Turn" in message:
+            banner = Text()
+            banner.append(" \u2550" * 12, style=Style(color="#f0883e"))
+            banner.append(f" {message} ", style=Style(bold=True, color="#f0883e"))
+            banner.append("\u2550" * 12, style=Style(color="#f0883e"))
+            self.write(banner)
             return
 
         line = Text()
@@ -57,6 +88,11 @@ class CombatLogWidget(RichLog):
         # Turn prefix for combat events
         if self._current_turn > 0 and category not in ("system", "turn"):
             line.append(f"[T{self._current_turn}] ", style=Style(color="#6e7681"))
+
+        # Category icon
+        icon = _CATEGORY_ICONS.get(category)
+        if icon:
+            line.append(f"{icon} ", style=Style(color=color))
 
         bold = category in _BOLD_CATEGORIES
         italic = category == "narration"

--- a/emberblast/tui/widgets/combat_log.py
+++ b/emberblast/tui/widgets/combat_log.py
@@ -17,6 +17,14 @@ DEFAULT_MAX_ENTRIES = 100
 class CombatLogWidget(Widget):
     """Scrollable, color-coded combat log."""
 
+    DEFAULT_CSS = """
+    CombatLogWidget {
+        background: #161b22;
+        padding: 1;
+        overflow-y: auto;
+    }
+    """
+
     def __init__(self, max_entries: int = DEFAULT_MAX_ENTRIES, **kwargs) -> None:
         super().__init__(**kwargs)
         self._entries: deque[Tuple[str, str]] = deque(maxlen=max_entries)

--- a/emberblast/tui/widgets/combat_log.py
+++ b/emberblast/tui/widgets/combat_log.py
@@ -2,85 +2,68 @@
 
 from __future__ import annotations
 
-from collections import deque
-from typing import Tuple
-
 from rich.style import Style
 from rich.text import Text
-from textual.widget import Widget
+from textual.widgets import RichLog
 
 from emberblast.tui.styles import LOG_COLORS
 
-DEFAULT_MAX_ENTRIES = 100
-
 # Categories that get special formatting
-_SEPARATOR_CATEGORIES = {"system"}
 _BOLD_CATEGORIES = {"turn", "victory", "death", "level_up", "critical"}
 
 
-class CombatLogWidget(Widget):
-    """Scrollable, color-coded combat log."""
+class CombatLogWidget(RichLog):
+    """Scrollable, color-coded combat log using Textual's RichLog for real scrolling."""
 
     DEFAULT_CSS = """
     CombatLogWidget {
         background: #161b22;
-        padding: 1;
-        overflow-y: auto;
+        border: solid #30363d;
+        scrollbar-size: 1 1;
     }
     """
 
-    def __init__(self, max_entries: int = DEFAULT_MAX_ENTRIES, **kwargs) -> None:
-        super().__init__(**kwargs)
-        self._entries: deque[Tuple[str, str]] = deque(maxlen=max_entries)
+    def __init__(self, **kwargs) -> None:
+        super().__init__(highlight=False, markup=False, wrap=True, auto_scroll=True, **kwargs)
         self._current_turn: int = 0
+        self._initialized: bool = False
+
+    def on_mount(self) -> None:
+        """Write the header when mounted."""
+        if not self._initialized:
+            self._initialized = True
+            header = Text()
+            header.append("COMBAT LOG", style=Style(bold=True, color="#f0883e"))
+            self.write(header)
+            sep = Text("─" * 40, style=Style(color="#30363d"))
+            self.write(sep)
 
     def set_turn(self, turn: int) -> None:
         """Track the current turn number for log prefixes."""
         self._current_turn = turn
 
     def add_entry(self, message: str, category: str = "system") -> None:
-        """Append a log entry and refresh."""
-        self._entries.append((message, category, self._current_turn))
-        self.refresh()
+        """Append a styled log entry."""
+        color = LOG_COLORS.get(category, LOG_COLORS["system"])
+
+        # Separator lines
+        if message == "---":
+            sep = Text("─" * 40, style=Style(color="#30363d"))
+            self.write(sep)
+            return
+
+        line = Text()
+
+        # Turn prefix for combat events
+        if self._current_turn > 0 and category not in ("system", "turn"):
+            line.append(f"[T{self._current_turn}] ", style=Style(color="#6e7681"))
+
+        bold = category in _BOLD_CATEGORIES
+        italic = category == "narration"
+        line.append(message, style=Style(color=color, bold=bold, italic=italic))
+
+        self.write(line)
 
     def clear_log(self) -> None:
         """Remove all log entries."""
-        self._entries.clear()
-        self.refresh()
-
-    def _build_log_text(self) -> Text:
-        """Build a Rich Text object for the log display."""
-        result = Text()
-        # Header
-        result.append("COMBAT LOG\n", style=Style(bold=True, color="#f0883e"))
-        result.append("─" * 30 + "\n", style=Style(color="#30363d"))
-
-        if not self._entries:
-            result.append("Awaiting battle...", style=Style(dim=True))
-            return result
-
-        for entry in self._entries:
-            message, category = entry[0], entry[1]
-            turn = entry[2] if len(entry) > 2 else 0
-            color = LOG_COLORS.get(category, LOG_COLORS["system"])
-
-            # Separator lines stay plain
-            if message == "---":
-                result.append("─" * 30 + "\n", style=Style(color="#30363d"))
-                continue
-
-            bold = category in _BOLD_CATEGORIES
-            italic = category == "narration"
-            style = Style(color=color, bold=bold, italic=italic)
-
-            # Add turn prefix for combat events (not system/separator)
-            if turn > 0 and category not in _SEPARATOR_CATEGORIES and category != "turn":
-                result.append(f"[T{turn}] ", style=Style(color="#6e7681", dim=True))
-
-            result.append(f"{message}\n", style=style)
-
-        return result
-
-    def render(self) -> Text:
-        """Render the widget content."""
-        return self._build_log_text()
+        self.clear()

--- a/emberblast/tui/widgets/combat_log.py
+++ b/emberblast/tui/widgets/combat_log.py
@@ -100,6 +100,14 @@ class CombatLogWidget(RichLog):
 
         self.write(line)
 
+    def pause_scroll(self) -> None:
+        """Temporarily disable auto-scroll (e.g. during movement selection)."""
+        self.auto_scroll = False
+
+    def resume_scroll(self) -> None:
+        """Re-enable auto-scroll."""
+        self.auto_scroll = True
+
     def clear_log(self) -> None:
         """Remove all log entries."""
         self.clear()

--- a/emberblast/tui/widgets/enemy_panel.py
+++ b/emberblast/tui/widgets/enemy_panel.py
@@ -8,13 +8,12 @@ from rich.style import Style
 from rich.text import Text
 from textual.widget import Widget
 
-MINI_BAR_W = 12
+MINI_BAR_W = 10
 FILLED = "\u2588"  # █
 EMPTY = "\u2591"  # ░
 
 
 def _bar_color(ratio: float) -> str:
-    """Return a hex color based on the health ratio."""
     if ratio > 0.50:
         return "#3fb950"
     if ratio > 0.25:
@@ -23,15 +22,15 @@ def _bar_color(ratio: float) -> str:
 
 
 class EnemyPanelWidget(Widget):
-    """Dedicated scrollable panel showing all enemy information."""
+    """Dedicated panel showing all enemy information with mini-cards."""
 
     DEFAULT_CSS = """
     EnemyPanelWidget {
-        background: #161b22;
-        padding: 1;
-        border: solid #f85149;
+        background: #0d1117;
+        padding: 0 1;
+        border: tall #f85149;
         height: auto;
-        max-height: 50%;
+        min-height: 8;
     }
     """
 
@@ -40,45 +39,38 @@ class EnemyPanelWidget(Widget):
         self._enemies: List[object] = []
 
     def update_enemies(self, enemies: List[object]) -> None:
-        """Update the enemy list and refresh."""
         self._enemies = list(enemies)
         self.refresh()
 
     def _build_panel_text(self) -> Text:
-        """Build a Rich Text object for the enemy panel."""
         result = Text()
 
         # Header
-        result.append(" \u2620 ", style=Style(color="#f85149"))
-        result.append("ENEMIES", style=Style(bold=True, color="#f85149"))
         result.append("\n")
-        result.append(" " + "\u2500" * 24 + "\n", style=Style(color="#30363d"))
+        result.append("  \u2620 ", style=Style(color="#f85149", bold=True))
+        result.append("ENEMIES", style=Style(bold=True, color="#f85149"))
 
         alive = [e for e in self._enemies if hasattr(e, "is_alive") and e.is_alive()]
         dead = [e for e in self._enemies if hasattr(e, "is_alive") and not e.is_alive()]
 
+        result.append(f"  ({len(alive)} alive", style=Style(color="#6e7681"))
+        if dead:
+            result.append(f", {len(dead)} dead", style=Style(color="#484f58"))
+        result.append(")\n", style=Style(color="#6e7681"))
+
         if not alive and not dead:
-            result.append(" No enemies", style=Style(dim=True))
+            result.append("  No enemies nearby", style=Style(dim=True))
             return result
 
-        for e in alive:
+        result.append(" \u2500" * 15 + "\n", style=Style(color="#21262d"))
+
+        for idx, e in enumerate(alive):
             ej = e.job.name if hasattr(e.job, "name") else str(e.job)
 
-            # Name + job + level
-            result.append(f" {e.name}", style=Style(bold=True, color="#f85149"))
-            result.append(f" {ej}", style=Style(color="#8b949e"))
-            result.append(f" Lv.{e.level}\n", style=Style(color="#f0883e"))
-
-            # HP bar
-            hp_ratio = e.life / e.health_points if e.health_points > 0 else 0
-            hp_color = _bar_color(hp_ratio)
-            filled = round(hp_ratio * MINI_BAR_W)
-            empty = MINI_BAR_W - filled
-
-            result.append("  HP ", style=Style(color="#8b949e"))
-            result.append(FILLED * filled, style=Style(color=hp_color))
-            result.append(EMPTY * empty, style=Style(color="#30363d"))
-            result.append(f" {e.life}/{e.health_points}\n", style=Style(dim=True))
+            # Name line: name + job + level
+            result.append(f"  {e.name}", style=Style(bold=True, color="#f85149"))
+            result.append(f"  {ej}", style=Style(color="#8b949e"))
+            result.append(f"  Lv.{e.level}", style=Style(color="#f0883e"))
 
             # Position
             if hasattr(e, "position") and e.position:
@@ -89,16 +81,62 @@ class EnemyPanelWidget(Widget):
                     pos_str = f"{convert_number_to_letter(pos[0])}{pos[1]}"
                 else:
                     pos_str = str(pos)
-                result.append(f"  Pos: {pos_str}\n", style=Style(dim=True))
+                result.append(f"  \u25c8{pos_str}", style=Style(color="#58a6ff"))
+            result.append("\n")
 
-        # Dead enemies
-        for e in dead:
-            ej = e.job.name if hasattr(e.job, "name") else str(e.job)
-            result.append(f" \u2620 {e.name}", style=Style(color="#484f58", strike=True))
-            result.append(f" {ej} DEAD\n", style=Style(color="#484f58"))
+            # HP bar
+            hp_ratio = e.life / e.health_points if e.health_points > 0 else 0
+            hp_color = _bar_color(hp_ratio)
+            filled = round(hp_ratio * MINI_BAR_W)
+            empty = MINI_BAR_W - filled
+
+            result.append("  HP ", style=Style(color="#6e7681"))
+            result.append(FILLED * filled, style=Style(color=hp_color))
+            result.append(EMPTY * empty, style=Style(color="#21262d"))
+            result.append(f" {e.life}/{e.health_points}", style=Style(color="#6e7681"))
+
+            # MP inline
+            if hasattr(e, "mana") and hasattr(e, "magic_points") and e.magic_points > 0:
+                result.append(f"  MP {e.mana}/{e.magic_points}", style=Style(color="#d2a8ff"))
+            result.append("\n")
+
+            # Key stats inline
+            stats_parts = []
+            if hasattr(e, "strength"):
+                stats_parts.append(f"STR:{e.strength}")
+            if hasattr(e, "intelligence"):
+                stats_parts.append(f"INT:{e.intelligence}")
+            if hasattr(e, "armour"):
+                stats_parts.append(f"ARM:{e.armour}")
+            if stats_parts:
+                result.append(f"  {' '.join(stats_parts)}\n", style=Style(color="#484f58"))
+
+            # Side effects
+            if hasattr(e, "side_effects") and e.side_effects:
+                for se in e.side_effects:
+                    se_name = se.name if hasattr(se, "name") else str(se)
+                    se_type = getattr(se, "effect_type", "buff")
+                    icon = "\u25b2" if se_type == "buff" else "\u25bc"
+                    color = "#3fb950" if se_type == "buff" else "#f85149"
+                    result.append(f"  {icon}{se_name}", style=Style(color=color))
+                    if hasattr(se, "duration"):
+                        result.append(f"({se.duration}t)", style=Style(color="#6e7681"))
+                    result.append(" ")
+                result.append("\n")
+
+            # Separator between enemies
+            if idx < len(alive) - 1:
+                result.append("  \u00b7 \u00b7 \u00b7\n", style=Style(color="#21262d"))
+
+        # Dead enemies compact
+        if dead:
+            result.append(" \u2500" * 15 + "\n", style=Style(color="#21262d"))
+            for e in dead:
+                ej = e.job.name if hasattr(e.job, "name") else str(e.job)
+                result.append(f"  \u2620 {e.name} {ej}", style=Style(color="#484f58", strike=True))
+                result.append(" DEAD\n", style=Style(color="#484f58"))
 
         return result
 
     def render(self) -> Text:
-        """Render the widget content."""
         return self._build_panel_text()

--- a/emberblast/tui/widgets/enemy_panel.py
+++ b/emberblast/tui/widgets/enemy_panel.py
@@ -37,6 +37,7 @@ class EnemyPanelWidget(RichLog):
         super().__init__(highlight=False, markup=False, wrap=True, auto_scroll=False, **kwargs)
         self._enemies: List[object] = []
         self._selected_idx: int = 0
+        self._rebuilding: bool = False
 
     def update_enemies(self, enemies: List[object]) -> None:
         self._enemies = list(enemies)
@@ -54,11 +55,21 @@ class EnemyPanelWidget(RichLog):
         self._selected_idx = (self._selected_idx + direction) % len(alive)
         self._rebuild()
 
+    def refresh(self, *args, **kwargs) -> None:
+        """Override refresh to rebuild content from stored enemy data."""
+        if self._enemies and not self._rebuilding:
+            self._rebuild()
+        return super().refresh(*args, **kwargs)
+
     def _rebuild(self) -> None:
         """Clear and rewrite all content."""
-        self.clear()
-        for line in self._build_lines():
-            self.write(line)
+        self._rebuilding = True
+        try:
+            self.clear()
+            for line in self._build_lines():
+                self.write(line)
+        finally:
+            self._rebuilding = False
 
     def _build_panel_text(self) -> Text:
         """Build full panel as single Text (for tests)."""

--- a/emberblast/tui/widgets/enemy_panel.py
+++ b/emberblast/tui/widgets/enemy_panel.py
@@ -6,7 +6,7 @@ from typing import List
 
 from rich.style import Style
 from rich.text import Text
-from textual.widget import Widget
+from textual.widgets import RichLog
 
 MINI_BAR_W = 10
 FILLED = "\u2588"  # █
@@ -21,7 +21,7 @@ def _bar_color(ratio: float) -> str:
     return "#f85149"
 
 
-class EnemyPanelWidget(Widget):
+class EnemyPanelWidget(RichLog):
     """Panel showing all enemies with Tab to cycle expanded details."""
 
     DEFAULT_CSS = """
@@ -29,13 +29,12 @@ class EnemyPanelWidget(Widget):
         background: #0d1117;
         padding: 0 1;
         border: tall #f85149;
-        height: auto;
-        min-height: 6;
+        scrollbar-size: 1 1;
     }
     """
 
     def __init__(self, **kwargs) -> None:
-        super().__init__(**kwargs)
+        super().__init__(highlight=False, markup=False, wrap=True, auto_scroll=False, **kwargs)
         self._enemies: List[object] = []
         self._selected_idx: int = 0
 
@@ -45,7 +44,7 @@ class EnemyPanelWidget(Widget):
         alive = [e for e in self._enemies if hasattr(e, "is_alive") and e.is_alive()]
         if self._selected_idx >= len(alive):
             self._selected_idx = 0
-        self.refresh()
+        self._rebuild()
 
     def cycle_enemy(self, direction: int = 1) -> None:
         """Cycle selected enemy by direction (+1 next, -1 prev)."""
@@ -53,47 +52,61 @@ class EnemyPanelWidget(Widget):
         if not alive:
             return
         self._selected_idx = (self._selected_idx + direction) % len(alive)
-        self.refresh()
+        self._rebuild()
+
+    def _rebuild(self) -> None:
+        """Clear and rewrite all content."""
+        self.clear()
+        for line in self._build_lines():
+            self.write(line)
 
     def _build_panel_text(self) -> Text:
+        """Build full panel as single Text (for tests)."""
         result = Text()
+        for line in self._build_lines():
+            result.append_text(line)
+            result.append("\n")
+        return result
+
+    def _build_lines(self) -> List[Text]:
+        """Build list of Text lines for the panel."""
+        lines: List[Text] = []
 
         # Header
-        result.append("\n")
-        result.append("  \u2620 ", style=Style(color="#f85149", bold=True))
-        result.append("ENEMIES", style=Style(bold=True, color="#f85149"))
+        header = Text()
+        header.append("  \u2620 ", style=Style(color="#f85149", bold=True))
+        header.append("ENEMIES", style=Style(bold=True, color="#f85149"))
 
         alive = [e for e in self._enemies if hasattr(e, "is_alive") and e.is_alive()]
         dead = [e for e in self._enemies if hasattr(e, "is_alive") and not e.is_alive()]
 
-        result.append(f"  ({len(alive)} alive", style=Style(color="#6e7681"))
+        header.append(f"  ({len(alive)} alive", style=Style(color="#6e7681"))
         if dead:
-            result.append(f", {len(dead)} dead", style=Style(color="#484f58"))
-        result.append(")", style=Style(color="#6e7681"))
+            header.append(f", {len(dead)} dead", style=Style(color="#484f58"))
+        header.append(")", style=Style(color="#6e7681"))
 
         if alive:
-            result.append("  [Tab] cycle", style=Style(color="#484f58"))
-        result.append("\n")
+            header.append("  [Tab] cycle", style=Style(color="#484f58"))
+        lines.append(header)
 
         if not alive and not dead:
-            result.append("  No enemies nearby", style=Style(dim=True))
-            return result
+            lines.append(Text("  No enemies nearby", style=Style(dim=True)))
+            return lines
 
-        result.append(" \u2500" * 15 + "\n", style=Style(color="#21262d"))
+        lines.append(Text(" \u2500" * 15, style=Style(color="#21262d")))
 
         for idx, e in enumerate(alive):
             is_selected = idx == self._selected_idx
             ej = e.job.name if hasattr(e.job, "name") else str(e.job)
 
-            # Selection indicator
+            # Name line
+            name_line = Text()
             prefix = " \u25b8 " if is_selected else "   "
-
-            # Name + job + level + position (compact)
             name_color = "#ff7b72" if is_selected else "#f85149"
-            result.append(prefix)
-            result.append(f"{e.name}", style=Style(bold=is_selected, color=name_color))
-            result.append(f" {ej}", style=Style(color="#8b949e"))
-            result.append(f" Lv.{e.level}", style=Style(color="#f0883e"))
+            name_line.append(prefix)
+            name_line.append(f"{e.name}", style=Style(bold=is_selected, color=name_color))
+            name_line.append(f" {ej}", style=Style(color="#8b949e"))
+            name_line.append(f" Lv.{e.level}", style=Style(color="#f0883e"))
 
             if hasattr(e, "position") and e.position:
                 pos = e.position
@@ -103,27 +116,27 @@ class EnemyPanelWidget(Widget):
                     pos_str = f"{convert_number_to_letter(pos[0])}{pos[1]}"
                 else:
                     pos_str = str(pos)
-                result.append(f" \u25c8{pos_str}", style=Style(color="#58a6ff"))
-            result.append("\n")
+                name_line.append(f" \u25c8{pos_str}", style=Style(color="#58a6ff"))
+            lines.append(name_line)
 
-            # HP bar — always shown for all enemies
+            # HP bar
+            hp_line = Text()
             hp_ratio = e.life / e.health_points if e.health_points > 0 else 0
             hp_color = _bar_color(hp_ratio)
             filled = round(hp_ratio * MINI_BAR_W)
             empty = MINI_BAR_W - filled
 
-            result.append("   HP ", style=Style(color="#6e7681"))
-            result.append(FILLED * filled, style=Style(color=hp_color))
-            result.append(EMPTY * empty, style=Style(color="#21262d"))
-            result.append(f" {e.life}/{e.health_points}", style=Style(color="#6e7681"))
+            hp_line.append("   HP ", style=Style(color="#6e7681"))
+            hp_line.append(FILLED * filled, style=Style(color=hp_color))
+            hp_line.append(EMPTY * empty, style=Style(color="#21262d"))
+            hp_line.append(f" {e.life}/{e.health_points}", style=Style(color="#6e7681"))
 
             if hasattr(e, "mana") and hasattr(e, "magic_points") and e.magic_points > 0:
-                result.append(f"  MP {e.mana}/{e.magic_points}", style=Style(color="#d2a8ff"))
-            result.append("\n")
+                hp_line.append(f"  MP {e.mana}/{e.magic_points}", style=Style(color="#d2a8ff"))
+            lines.append(hp_line)
 
             # Expanded details for selected enemy
             if is_selected:
-                # Stats
                 stats_parts = []
                 for attr, label in [
                     ("strength", "STR"),
@@ -137,31 +150,43 @@ class EnemyPanelWidget(Widget):
                     if val is not None:
                         stats_parts.append(f"{label} {val}")
                 if stats_parts:
-                    result.append("   ", style=Style(color="#484f58"))
-                    result.append("  ".join(stats_parts) + "\n", style=Style(color="#484f58"))
+                    lines.append(Text("   " + "  ".join(stats_parts), style=Style(color="#484f58")))
 
                 # Side effects
                 if hasattr(e, "side_effects") and e.side_effects:
+                    se_line = Text()
                     for se in e.side_effects:
                         se_name = se.name if hasattr(se, "name") else str(se)
                         se_type = getattr(se, "effect_type", "buff")
                         icon = "\u25b2" if se_type == "buff" else "\u25bc"
                         color = "#3fb950" if se_type == "buff" else "#f85149"
-                        result.append(f"   {icon}{se_name}", style=Style(color=color))
+                        se_line.append(f"   {icon}{se_name}", style=Style(color=color))
                         if hasattr(se, "duration"):
-                            result.append(f"({se.duration}t)", style=Style(color="#6e7681"))
-                        result.append(" ")
-                    result.append("\n")
+                            se_line.append(f"({se.duration}t)", style=Style(color="#6e7681"))
+                        se_line.append(" ")
+                    lines.append(se_line)
 
-        # Dead enemies — single compact line
+        # Dead enemies
         if dead:
-            result.append(" \u2500" * 15 + "\n", style=Style(color="#21262d"))
+            lines.append(Text(" \u2500" * 15, style=Style(color="#21262d")))
             for e in dead:
                 ej = e.job.name if hasattr(e.job, "name") else str(e.job)
-                result.append(f"   \u2620 {e.name} {ej}", style=Style(color="#484f58", strike=True))
-                result.append(" DEAD\n", style=Style(color="#484f58"))
+                dead_line = Text()
+                dead_line.append(
+                    f"   \u2620 {e.name} {ej}",
+                    style=Style(color="#484f58", strike=True),
+                )
+                dead_line.append(" DEAD", style=Style(color="#484f58"))
+                lines.append(dead_line)
 
-        return result
+        return lines
 
     def render(self) -> Text:
-        return self._build_panel_text()
+        # Fallback for initial empty state
+        if not self._enemies:
+            result = Text()
+            result.append("  \u2620 ", style=Style(color="#f85149", bold=True))
+            result.append("ENEMIES", style=Style(bold=True, color="#f85149"))
+            result.append("  (0 alive)", style=Style(color="#6e7681"))
+            return result
+        return Text("")

--- a/emberblast/tui/widgets/enemy_panel.py
+++ b/emberblast/tui/widgets/enemy_panel.py
@@ -1,0 +1,104 @@
+"""Enemy panel widget — dedicated panel showing all enemy info."""
+
+from __future__ import annotations
+
+from typing import List
+
+from rich.style import Style
+from rich.text import Text
+from textual.widget import Widget
+
+MINI_BAR_W = 12
+FILLED = "\u2588"  # █
+EMPTY = "\u2591"  # ░
+
+
+def _bar_color(ratio: float) -> str:
+    """Return a hex color based on the health ratio."""
+    if ratio > 0.50:
+        return "#3fb950"
+    if ratio > 0.25:
+        return "#e3b341"
+    return "#f85149"
+
+
+class EnemyPanelWidget(Widget):
+    """Dedicated scrollable panel showing all enemy information."""
+
+    DEFAULT_CSS = """
+    EnemyPanelWidget {
+        background: #161b22;
+        padding: 1;
+        border: solid #f85149;
+        height: auto;
+        max-height: 50%;
+    }
+    """
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._enemies: List[object] = []
+
+    def update_enemies(self, enemies: List[object]) -> None:
+        """Update the enemy list and refresh."""
+        self._enemies = list(enemies)
+        self.refresh()
+
+    def _build_panel_text(self) -> Text:
+        """Build a Rich Text object for the enemy panel."""
+        result = Text()
+
+        # Header
+        result.append(" \u2620 ", style=Style(color="#f85149"))
+        result.append("ENEMIES", style=Style(bold=True, color="#f85149"))
+        result.append("\n")
+        result.append(" " + "\u2500" * 24 + "\n", style=Style(color="#30363d"))
+
+        alive = [e for e in self._enemies if hasattr(e, "is_alive") and e.is_alive()]
+        dead = [e for e in self._enemies if hasattr(e, "is_alive") and not e.is_alive()]
+
+        if not alive and not dead:
+            result.append(" No enemies", style=Style(dim=True))
+            return result
+
+        for e in alive:
+            ej = e.job.name if hasattr(e.job, "name") else str(e.job)
+
+            # Name + job + level
+            result.append(f" {e.name}", style=Style(bold=True, color="#f85149"))
+            result.append(f" {ej}", style=Style(color="#8b949e"))
+            result.append(f" Lv.{e.level}\n", style=Style(color="#f0883e"))
+
+            # HP bar
+            hp_ratio = e.life / e.health_points if e.health_points > 0 else 0
+            hp_color = _bar_color(hp_ratio)
+            filled = round(hp_ratio * MINI_BAR_W)
+            empty = MINI_BAR_W - filled
+
+            result.append("  HP ", style=Style(color="#8b949e"))
+            result.append(FILLED * filled, style=Style(color=hp_color))
+            result.append(EMPTY * empty, style=Style(color="#30363d"))
+            result.append(f" {e.life}/{e.health_points}\n", style=Style(dim=True))
+
+            # Position
+            if hasattr(e, "position") and e.position:
+                pos = e.position
+                if isinstance(pos, list) and len(pos) == 2:
+                    from emberblast.utils import convert_number_to_letter
+
+                    pos_str = f"{convert_number_to_letter(pos[0])}{pos[1]}"
+                else:
+                    pos_str = str(pos)
+                result.append(f"  Pos: {pos_str}\n", style=Style(dim=True))
+
+        # Dead enemies
+        for e in dead:
+            ej = e.job.name if hasattr(e.job, "name") else str(e.job)
+            result.append(f" \u2620 {e.name}", style=Style(color="#484f58", strike=True))
+            result.append(f" {ej} DEAD\n", style=Style(color="#484f58"))
+
+        return result
+
+    def render(self) -> Text:
+        """Render the widget content."""
+        return self._build_panel_text()

--- a/emberblast/tui/widgets/enemy_panel.py
+++ b/emberblast/tui/widgets/enemy_panel.py
@@ -22,7 +22,7 @@ def _bar_color(ratio: float) -> str:
 
 
 class EnemyPanelWidget(Widget):
-    """Dedicated panel showing all enemy information with mini-cards."""
+    """Panel showing all enemies with Tab to cycle expanded details."""
 
     DEFAULT_CSS = """
     EnemyPanelWidget {
@@ -30,16 +30,29 @@ class EnemyPanelWidget(Widget):
         padding: 0 1;
         border: tall #f85149;
         height: auto;
-        min-height: 8;
+        min-height: 6;
     }
     """
 
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
         self._enemies: List[object] = []
+        self._selected_idx: int = 0
 
     def update_enemies(self, enemies: List[object]) -> None:
         self._enemies = list(enemies)
+        # Clamp selection
+        alive = [e for e in self._enemies if hasattr(e, "is_alive") and e.is_alive()]
+        if self._selected_idx >= len(alive):
+            self._selected_idx = 0
+        self.refresh()
+
+    def cycle_enemy(self, direction: int = 1) -> None:
+        """Cycle selected enemy by direction (+1 next, -1 prev)."""
+        alive = [e for e in self._enemies if hasattr(e, "is_alive") and e.is_alive()]
+        if not alive:
+            return
+        self._selected_idx = (self._selected_idx + direction) % len(alive)
         self.refresh()
 
     def _build_panel_text(self) -> Text:
@@ -56,7 +69,11 @@ class EnemyPanelWidget(Widget):
         result.append(f"  ({len(alive)} alive", style=Style(color="#6e7681"))
         if dead:
             result.append(f", {len(dead)} dead", style=Style(color="#484f58"))
-        result.append(")\n", style=Style(color="#6e7681"))
+        result.append(")", style=Style(color="#6e7681"))
+
+        if alive:
+            result.append("  [Tab] cycle", style=Style(color="#484f58"))
+        result.append("\n")
 
         if not alive and not dead:
             result.append("  No enemies nearby", style=Style(dim=True))
@@ -65,14 +82,19 @@ class EnemyPanelWidget(Widget):
         result.append(" \u2500" * 15 + "\n", style=Style(color="#21262d"))
 
         for idx, e in enumerate(alive):
+            is_selected = idx == self._selected_idx
             ej = e.job.name if hasattr(e.job, "name") else str(e.job)
 
-            # Name line: name + job + level
-            result.append(f"  {e.name}", style=Style(bold=True, color="#f85149"))
-            result.append(f"  {ej}", style=Style(color="#8b949e"))
-            result.append(f"  Lv.{e.level}", style=Style(color="#f0883e"))
+            # Selection indicator
+            prefix = " \u25b8 " if is_selected else "   "
 
-            # Position
+            # Name + job + level + position (compact)
+            name_color = "#ff7b72" if is_selected else "#f85149"
+            result.append(prefix)
+            result.append(f"{e.name}", style=Style(bold=is_selected, color=name_color))
+            result.append(f" {ej}", style=Style(color="#8b949e"))
+            result.append(f" Lv.{e.level}", style=Style(color="#f0883e"))
+
             if hasattr(e, "position") and e.position:
                 pos = e.position
                 if isinstance(pos, list) and len(pos) == 2:
@@ -81,59 +103,62 @@ class EnemyPanelWidget(Widget):
                     pos_str = f"{convert_number_to_letter(pos[0])}{pos[1]}"
                 else:
                     pos_str = str(pos)
-                result.append(f"  \u25c8{pos_str}", style=Style(color="#58a6ff"))
+                result.append(f" \u25c8{pos_str}", style=Style(color="#58a6ff"))
             result.append("\n")
 
-            # HP bar
+            # HP bar — always shown for all enemies
             hp_ratio = e.life / e.health_points if e.health_points > 0 else 0
             hp_color = _bar_color(hp_ratio)
             filled = round(hp_ratio * MINI_BAR_W)
             empty = MINI_BAR_W - filled
 
-            result.append("  HP ", style=Style(color="#6e7681"))
+            result.append("   HP ", style=Style(color="#6e7681"))
             result.append(FILLED * filled, style=Style(color=hp_color))
             result.append(EMPTY * empty, style=Style(color="#21262d"))
             result.append(f" {e.life}/{e.health_points}", style=Style(color="#6e7681"))
 
-            # MP inline
             if hasattr(e, "mana") and hasattr(e, "magic_points") and e.magic_points > 0:
                 result.append(f"  MP {e.mana}/{e.magic_points}", style=Style(color="#d2a8ff"))
             result.append("\n")
 
-            # Key stats inline
-            stats_parts = []
-            if hasattr(e, "strength"):
-                stats_parts.append(f"STR:{e.strength}")
-            if hasattr(e, "intelligence"):
-                stats_parts.append(f"INT:{e.intelligence}")
-            if hasattr(e, "armour"):
-                stats_parts.append(f"ARM:{e.armour}")
-            if stats_parts:
-                result.append(f"  {' '.join(stats_parts)}\n", style=Style(color="#484f58"))
+            # Expanded details for selected enemy
+            if is_selected:
+                # Stats
+                stats_parts = []
+                for attr, label in [
+                    ("strength", "STR"),
+                    ("intelligence", "INT"),
+                    ("accuracy", "ACC"),
+                    ("armour", "ARM"),
+                    ("magic_resist", "RES"),
+                    ("move_speed", "SPD"),
+                ]:
+                    val = getattr(e, attr, None)
+                    if val is not None:
+                        stats_parts.append(f"{label} {val}")
+                if stats_parts:
+                    result.append("   ", style=Style(color="#484f58"))
+                    result.append("  ".join(stats_parts) + "\n", style=Style(color="#484f58"))
 
-            # Side effects
-            if hasattr(e, "side_effects") and e.side_effects:
-                for se in e.side_effects:
-                    se_name = se.name if hasattr(se, "name") else str(se)
-                    se_type = getattr(se, "effect_type", "buff")
-                    icon = "\u25b2" if se_type == "buff" else "\u25bc"
-                    color = "#3fb950" if se_type == "buff" else "#f85149"
-                    result.append(f"  {icon}{se_name}", style=Style(color=color))
-                    if hasattr(se, "duration"):
-                        result.append(f"({se.duration}t)", style=Style(color="#6e7681"))
-                    result.append(" ")
-                result.append("\n")
+                # Side effects
+                if hasattr(e, "side_effects") and e.side_effects:
+                    for se in e.side_effects:
+                        se_name = se.name if hasattr(se, "name") else str(se)
+                        se_type = getattr(se, "effect_type", "buff")
+                        icon = "\u25b2" if se_type == "buff" else "\u25bc"
+                        color = "#3fb950" if se_type == "buff" else "#f85149"
+                        result.append(f"   {icon}{se_name}", style=Style(color=color))
+                        if hasattr(se, "duration"):
+                            result.append(f"({se.duration}t)", style=Style(color="#6e7681"))
+                        result.append(" ")
+                    result.append("\n")
 
-            # Separator between enemies
-            if idx < len(alive) - 1:
-                result.append("  \u00b7 \u00b7 \u00b7\n", style=Style(color="#21262d"))
-
-        # Dead enemies compact
+        # Dead enemies — single compact line
         if dead:
             result.append(" \u2500" * 15 + "\n", style=Style(color="#21262d"))
             for e in dead:
                 ej = e.job.name if hasattr(e.job, "name") else str(e.job)
-                result.append(f"  \u2620 {e.name} {ej}", style=Style(color="#484f58", strike=True))
+                result.append(f"   \u2620 {e.name} {ej}", style=Style(color="#484f58", strike=True))
                 result.append(" DEAD\n", style=Style(color="#484f58"))
 
         return result

--- a/emberblast/tui/widgets/map_grid.py
+++ b/emberblast/tui/widgets/map_grid.py
@@ -23,17 +23,20 @@ _VALUE_TO_TERRAIN: Dict[int, str] = {
     5: "forest",
 }
 
-# Terrain rendering: (symbol, foreground, background) — 5-char wide cells
+# Terrain rendering: (symbol, foreground, background) — 6-char wide cells
 _TERRAIN_STYLE: Dict[str, tuple] = {
-    "plains": (" \u00b7.\u00b7 ", "#484f58", "#1a1e24"),
-    "wall": (" \u2588\u2588\u2588 ", "#6e7681", "#2d333b"),
-    "water": (" \u2248\u2248\u2248 ", "#58a6ff", "#0c2d4a"),
-    "mountain": (" /\u25b2\\ ", "#f0883e", "#2a1a0a"),
-    "forest": (" \u2660\u2663\u2660 ", "#3fb950", "#0a2a0f"),
+    "plains": ("  \u00b7\u00b7  ", "#484f58", "#131820"),
+    "wall": ("  \u2588\u2588  ", "#6e7681", "#2d333b"),
+    "water": ("  \u2248\u2248  ", "#58a6ff", "#0a2240"),
+    "mountain": ("  /\\  ", "#f0883e", "#2a1a0a"),
+    "forest": ("  \u2663\u2663  ", "#3fb950", "#0a2a0f"),
 }
 
-# Cell width must match symbol length
-CELL_WIDTH = 5
+# Highlight terrain symbols (replace symbol with directional markers)
+_HIGHLIGHT_SYMBOL = "  \u25aa\u25aa  "
+_FLASH_SYMBOL = "  \u25c6\u25c6  "
+
+CELL_WIDTH = 6
 
 
 class MapWidget(Widget):
@@ -42,8 +45,8 @@ class MapWidget(Widget):
     DEFAULT_CSS = """
     MapWidget {
         background: #0d1117;
-        padding: 1;
-        border: solid #f0883e;
+        padding: 0 1;
+        border: tall #f0883e;
         height: 1fr;
     }
     """
@@ -68,7 +71,6 @@ class MapWidget(Widget):
         flash_cells: Optional[Set[str]] = None,
         highlight_cells: Optional[Set[str]] = None,
     ) -> None:
-        """Update the map data and trigger a refresh."""
         self._matrix = matrix
         self._grid_size = size
         self._players = players
@@ -79,9 +81,8 @@ class MapWidget(Widget):
         self.refresh()
 
     def _build_grid_text(self) -> Text:
-        """Build a Rich Text object representing the full grid."""
         if not self._matrix or self._grid_size == 0:
-            return Text("No map data")
+            return Text("  No map data")
 
         # Index players by (row, col)
         player_positions: Dict[tuple, list] = {}
@@ -100,22 +101,27 @@ class MapWidget(Widget):
             player_positions.setdefault(key, []).append(p)
 
         result = Text()
+        border_color = "#f0883e"
+        border_style = Style(color=border_color)
+        header_style = Style(bold=True, color="#6e7681")
 
         # Column headers
-        result.append("      ")
+        result.append("\n")
+        result.append("       ")
         for col in range(self._grid_size):
-            result.append(f" {col:^4}", style=Style(bold=True, color="#6e7681"))
+            result.append(f"  {col:<4}", style=header_style)
         result.append("\n")
 
-        # Top border — double-line box drawing
-        border_style = Style(color="#f0883e")
-        result.append("    \u2554\u2550", style=border_style)
-        result.append("\u2550\u2550\u2550\u2550\u2550" * self._grid_size, style=border_style)
+        # Top border — heavy double-line
+        result.append("     \u2554", style=border_style)
+        result.append("\u2550" * (CELL_WIDTH * self._grid_size + 1), style=border_style)
         result.append("\u2557\n", style=border_style)
 
         for row in range(self._grid_size):
             row_label = convert_number_to_letter(row)
-            result.append(f"  {row_label} \u2551 ", style=Style(bold=True, color="#6e7681"))
+
+            # Main cell row
+            result.append(f"   {row_label} \u2551", style=Style(bold=True, color="#8b949e"))
 
             for col in range(self._grid_size):
                 cell_value = self._matrix[row][col]
@@ -137,31 +143,43 @@ class MapWidget(Widget):
                         bold=True,
                         blink=is_active,
                     )
-                    result.append(f" [{token}]", style=style)
+                    result.append(f" [{token}] ", style=style)
                 elif cell_value == 0:
-                    result.append("     ")
+                    result.append(" " * CELL_WIDTH)
                 else:
                     terrain_name = _VALUE_TO_TERRAIN.get(cell_value, "plains")
                     symbol, fg, bg = _TERRAIN_STYLE.get(terrain_name, _TERRAIN_STYLE["plains"])
 
                     if position_str in self._flash_cells:
                         style = Style(color="#000000", bgcolor="#00ffff", bold=True)
+                        result.append(_FLASH_SYMBOL, style=style)
                     elif position_str in self._highlight_cells:
-                        style = Style(color="#00ffff", bgcolor="#1a4040", bold=True)
+                        style = Style(color="#00ffff", bgcolor="#1a3a3a", bold=True)
+                        result.append(_HIGHLIGHT_SYMBOL, style=style)
                     else:
                         style = Style(color=fg, bgcolor=bg)
-
-                    result.append(symbol, style=style)
+                        result.append(symbol, style=style)
 
             result.append("\u2551\n", style=border_style)
 
+            # Spacing row between grid rows (half-height visual separator)
+            if row < self._grid_size - 1:
+                result.append("     \u2551", style=border_style)
+                for col in range(self._grid_size):
+                    cell_value = self._matrix[row][col]
+                    terrain_name = _VALUE_TO_TERRAIN.get(cell_value, "plains")
+                    _, _, bg = _TERRAIN_STYLE.get(terrain_name, _TERRAIN_STYLE["plains"])
+                    # Subtle row separator
+                    result.append("\u2500" * CELL_WIDTH, style=Style(color="#21262d"))
+                result.append("\u2551\n", style=border_style)
+
         # Bottom border
-        result.append("    \u255a\u2550", style=border_style)
-        result.append("\u2550\u2550\u2550\u2550\u2550" * self._grid_size, style=border_style)
+        result.append("     \u255a", style=border_style)
+        result.append("\u2550" * (CELL_WIDTH * self._grid_size + 1), style=border_style)
         result.append("\u255d\n", style=border_style)
 
-        # Legend
-        result.append("\n  ")
+        # Legend — player tokens
+        result.append("     ")
         for p in self._players:
             if hasattr(p, "is_alive") and not p.is_alive():
                 continue
@@ -173,9 +191,9 @@ class MapWidget(Widget):
             result.append(f"[{token}]", style=Style(color=colors["fg"], bgcolor=colors["bg"], bold=True))
             result.append(f" {p.name}", style=Style(color="#8b949e"))
             result.append("  ")
+        result.append("\n")
 
         return result
 
     def render(self) -> Text:
-        """Render the widget content."""
         return self._build_grid_text()

--- a/emberblast/tui/widgets/map_grid.py
+++ b/emberblast/tui/widgets/map_grid.py
@@ -10,14 +10,11 @@ from textual.widget import Widget
 
 from emberblast.tui.styles import (
     TEAM_COLORS,
-    TERRAIN_COLORS,
     get_player_token,
-    get_terrain_cell,
 )
 from emberblast.utils import convert_number_to_letter
 
 # Map matrix integer values to terrain type names.
-# 0 is always void; 1 defaults to plains.
 _VALUE_TO_TERRAIN: Dict[int, str] = {
     1: "plains",
     2: "wall",
@@ -26,7 +23,16 @@ _VALUE_TO_TERRAIN: Dict[int, str] = {
     5: "forest",
 }
 
-# Cell width: 4 chars per cell (symbol + padding) for better readability
+# Terrain rendering: (symbol, foreground, background)
+_TERRAIN_STYLE: Dict[str, tuple] = {
+    "plains": (" ∙∙ ", "#484f58", "#1a1e24"),
+    "wall": (" ██ ", "#6e7681", "#2d333b"),
+    "water": (" ~~ ", "#58a6ff", "#0c2d4a"),
+    "mountain": (" /\\ ", "#f0883e", "#2a1a0a"),
+    "forest": (" ♣♣ ", "#3fb950", "#0a2a0f"),
+}
+
+# Cell width must match symbol length
 CELL_WIDTH = 4
 
 
@@ -37,7 +43,7 @@ class MapWidget(Widget):
     MapWidget {
         background: #0d1117;
         padding: 1;
-        border: solid #30363d;
+        border: solid #f0883e;
     }
     """
 
@@ -76,7 +82,7 @@ class MapWidget(Widget):
         if not self._matrix or self._grid_size == 0:
             return Text("No map data")
 
-        # Index players by (row, col) for fast lookup
+        # Index players by (row, col)
         player_positions: Dict[tuple, list] = {}
         for p in self._players:
             if hasattr(p, "is_alive") and not p.is_alive():
@@ -94,29 +100,25 @@ class MapWidget(Widget):
 
         result = Text()
 
-        # Column headers — wider spacing to match cells
-        result.append("    ")  # row label padding
+        # Column headers
+        result.append("     ")
         for col in range(self._grid_size):
-            header = f"{col:^{CELL_WIDTH}}"
-            result.append(header, style=Style(bold=True, dim=True))
+            result.append(f" {col:^3}", style=Style(bold=True, color="#6e7681"))
         result.append("\n")
 
         # Top border
-        result.append("   ┌")
-        result.append("─" * (self._grid_size * CELL_WIDTH))
-        result.append("┐\n", style=Style(color="#30363d"))
+        result.append("   ┌─")
+        result.append("────" * self._grid_size)
+        result.append("┐\n", style=Style(color="#f0883e"))
 
-        # Rows
         for row in range(self._grid_size):
             row_label = convert_number_to_letter(row)
-            result.append(f" {row_label} │", style=Style(bold=True, dim=True))
+            result.append(f" {row_label} │ ", style=Style(bold=True, color="#6e7681"))
 
             for col in range(self._grid_size):
                 cell_value = self._matrix[row][col]
                 position_key = (row, col)
                 position_str = f"{row_label}{col}"
-
-                # Check for players at this position
                 players_here = player_positions.get(position_key, [])
 
                 if players_here:
@@ -133,38 +135,31 @@ class MapWidget(Widget):
                         bold=True,
                         blink=is_active,
                     )
-                    # Center token in cell
-                    cell = f" {token} "
-                    result.append(cell, style=style)
+                    result.append(f" {token} ", style=style)
                 elif cell_value == 0:
-                    # Void cell
-                    result.append(" " * CELL_WIDTH)
+                    result.append("    ")
                 else:
                     terrain_name = _VALUE_TO_TERRAIN.get(cell_value, "plains")
-                    symbol = get_terrain_cell(terrain_name)
-                    color = TERRAIN_COLORS.get(terrain_name, TERRAIN_COLORS["plains"])
+                    symbol, fg, bg = _TERRAIN_STYLE.get(terrain_name, _TERRAIN_STYLE["plains"])
 
-                    if position_str in self._highlight_cells:
-                        # Movement possibility: bright cyan background
-                        style = Style(color="#00ffff", bgcolor="#1a4040", bold=True)
-                    elif position_str in self._flash_cells:
-                        # Flash effect: inverted colors for the selected cell
+                    if position_str in self._flash_cells:
                         style = Style(color="#000000", bgcolor="#00ffff", bold=True)
+                    elif position_str in self._highlight_cells:
+                        style = Style(color="#00ffff", bgcolor="#1a4040", bold=True)
                     else:
-                        style = Style(color=color)
+                        style = Style(color=fg, bgcolor=bg)
 
-                    cell = f" {symbol} "
-                    result.append(cell, style=style)
+                    result.append(symbol, style=style)
 
-            result.append("│\n", style=Style(color="#30363d"))
+            result.append("│\n", style=Style(color="#f0883e"))
 
         # Bottom border
-        result.append("   └")
-        result.append("─" * (self._grid_size * CELL_WIDTH))
-        result.append("┘\n", style=Style(color="#30363d"))
+        result.append("   └─")
+        result.append("────" * self._grid_size)
+        result.append("┘\n", style=Style(color="#f0883e"))
 
         # Legend
-        result.append("\n")
+        result.append("\n ")
         for p in self._players:
             if hasattr(p, "is_alive") and not p.is_alive():
                 continue
@@ -173,8 +168,9 @@ class MapWidget(Widget):
             is_friendly = p.name in self._friendly_names
             team = "friendly" if is_friendly else "enemy"
             colors = TEAM_COLORS[team]
-            result.append(f" {token}", style=Style(color=colors["fg"], bold=True))
-            result.append(f"={p.name} ", style=Style(dim=True))
+            result.append(f" {token}", style=Style(color=colors["fg"], bgcolor=colors["bg"], bold=True))
+            result.append(f"={p.name}", style=Style(color="#8b949e"))
+            result.append("  ")
 
         return result
 

--- a/emberblast/tui/widgets/map_grid.py
+++ b/emberblast/tui/widgets/map_grid.py
@@ -40,7 +40,7 @@ class MapWidget(Widget):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
         self._matrix: List[List[int]] = []
-        self._size: int = 0
+        self._grid_size: int = 0
         self._players: list = []
         self._active_player_name: str = ""
         self._friendly_names: Set[str] = set()
@@ -59,7 +59,7 @@ class MapWidget(Widget):
     ) -> None:
         """Update the map data and trigger a refresh."""
         self._matrix = matrix
-        self._size = size
+        self._grid_size = size
         self._players = players
         self._active_player_name = active_player_name
         self._friendly_names = friendly_names
@@ -69,7 +69,7 @@ class MapWidget(Widget):
 
     def _build_grid_text(self) -> Text:
         """Build a Rich Text object representing the full grid."""
-        if not self._matrix or self._size == 0:
+        if not self._matrix or self._grid_size == 0:
             return Text("No map data")
 
         # Index players by (row, col) for fast lookup
@@ -92,17 +92,17 @@ class MapWidget(Widget):
 
         # Column headers
         result.append("   ")
-        for col in range(self._size):
+        for col in range(self._grid_size):
             header = f"{col:>2} "
             result.append(header, style=Style(bold=True, dim=True))
         result.append("\n")
 
         # Rows
-        for row in range(self._size):
+        for row in range(self._grid_size):
             row_label = convert_number_to_letter(row)
             result.append(f"{row_label}  ", style=Style(bold=True, dim=True))
 
-            for col in range(self._size):
+            for col in range(self._grid_size):
                 cell_value = self._matrix[row][col]
                 position_key = (row, col)
                 position_str = f"{row_label}{col}"

--- a/emberblast/tui/widgets/map_grid.py
+++ b/emberblast/tui/widgets/map_grid.py
@@ -30,6 +30,13 @@ _VALUE_TO_TERRAIN: Dict[int, str] = {
 class MapWidget(Widget):
     """Renders a grid map with terrain, players, and highlights."""
 
+    DEFAULT_CSS = """
+    MapWidget {
+        background: #0d1117;
+        padding: 1;
+    }
+    """
+
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
         self._matrix: List[List[int]] = []

--- a/emberblast/tui/widgets/map_grid.py
+++ b/emberblast/tui/widgets/map_grid.py
@@ -23,20 +23,22 @@ _VALUE_TO_TERRAIN: Dict[int, str] = {
     5: "forest",
 }
 
-# Terrain rendering: (symbol, foreground, background) — 6-char wide cells
+# Terrain rendering: (top_symbol, bottom_symbol, foreground, background) — 8-char wide cells
 _TERRAIN_STYLE: Dict[str, tuple] = {
-    "plains": ("  \u00b7\u00b7  ", "#484f58", "#131820"),
-    "wall": ("  \u2588\u2588  ", "#6e7681", "#2d333b"),
-    "water": ("  \u2248\u2248  ", "#58a6ff", "#0a2240"),
-    "mountain": ("  /\\  ", "#f0883e", "#2a1a0a"),
-    "forest": ("  \u2663\u2663  ", "#3fb950", "#0a2a0f"),
+    "plains": ("   \u00b7\u00b7   ", "        ", "#484f58", "#131820"),
+    "wall": ("  \u2588\u2588\u2588\u2588  ", "  \u2588\u2588\u2588\u2588  ", "#6e7681", "#2d333b"),
+    "water": ("  \u2248\u2248\u2248\u2248  ", "  \u223c\u223c\u223c\u223c  ", "#58a6ff", "#0a2240"),
+    "mountain": ("  /\u25b2\\   ", "  \\__/  ", "#f0883e", "#2a1a0a"),
+    "forest": ("  \u2663\u2663\u2663\u2663  ", "  \u2502\u2502\u2502\u2502  ", "#3fb950", "#0a2a0f"),
 }
 
-# Highlight terrain symbols (replace symbol with directional markers)
-_HIGHLIGHT_SYMBOL = "  \u25aa\u25aa  "
-_FLASH_SYMBOL = "  \u25c6\u25c6  "
+# Highlight terrain symbols
+_HIGHLIGHT_TOP = "  \u25aa\u25aa\u25aa\u25aa  "
+_HIGHLIGHT_BOT = "  \u25aa\u25aa\u25aa\u25aa  "
+_FLASH_TOP = "  \u25c6\u25c6\u25c6\u25c6  "
+_FLASH_BOT = "  \u25c6\u25c6\u25c6\u25c6  "
 
-CELL_WIDTH = 6
+CELL_WIDTH = 8
 
 
 class MapWidget(Widget):
@@ -104,23 +106,28 @@ class MapWidget(Widget):
         border_color = "#f0883e"
         border_style = Style(color=border_color)
         header_style = Style(bold=True, color="#6e7681")
+        inner_width = CELL_WIDTH * self._grid_size + 1
 
         # Column headers
         result.append("\n")
         result.append("       ")
         for col in range(self._grid_size):
-            result.append(f"  {col:<4}", style=header_style)
+            label = str(col)
+            pad = CELL_WIDTH - len(label)
+            left_pad = pad // 2
+            right_pad = pad - left_pad
+            result.append(" " * left_pad + label + " " * right_pad, style=header_style)
         result.append("\n")
 
         # Top border — heavy double-line
         result.append("     \u2554", style=border_style)
-        result.append("\u2550" * (CELL_WIDTH * self._grid_size + 1), style=border_style)
+        result.append("\u2550" * inner_width, style=border_style)
         result.append("\u2557\n", style=border_style)
 
         for row in range(self._grid_size):
             row_label = convert_number_to_letter(row)
 
-            # Main cell row
+            # === Line 1: main content (player tokens or terrain top) ===
             result.append(f"   {row_label} \u2551", style=Style(bold=True, color="#8b949e"))
 
             for col in range(self._grid_size):
@@ -143,43 +150,84 @@ class MapWidget(Widget):
                         bold=True,
                         blink=is_active,
                     )
-                    result.append(f" [{token}] ", style=style)
+                    result.append(f"  [{token}]  ", style=style)
                 elif cell_value == 0:
                     result.append(" " * CELL_WIDTH)
                 else:
                     terrain_name = _VALUE_TO_TERRAIN.get(cell_value, "plains")
-                    symbol, fg, bg = _TERRAIN_STYLE.get(terrain_name, _TERRAIN_STYLE["plains"])
+                    top_sym, _, fg, bg = _TERRAIN_STYLE.get(terrain_name, _TERRAIN_STYLE["plains"])
 
                     if position_str in self._flash_cells:
                         style = Style(color="#000000", bgcolor="#00ffff", bold=True)
-                        result.append(_FLASH_SYMBOL, style=style)
+                        result.append(_FLASH_TOP, style=style)
                     elif position_str in self._highlight_cells:
                         style = Style(color="#00ffff", bgcolor="#1a3a3a", bold=True)
-                        result.append(_HIGHLIGHT_SYMBOL, style=style)
+                        result.append(_HIGHLIGHT_TOP, style=style)
                     else:
                         style = Style(color=fg, bgcolor=bg)
-                        result.append(symbol, style=style)
+                        result.append(top_sym, style=style)
+
+            result.append("\u2551\n", style=border_style)
+
+            # === Line 2: terrain bottom half ===
+            result.append("     \u2551", style=border_style)
+
+            for col in range(self._grid_size):
+                cell_value = self._matrix[row][col]
+                position_key = (row, col)
+                position_str = f"{convert_number_to_letter(row)}{col}"
+                players_here = player_positions.get(position_key, [])
+
+                if players_here:
+                    player = players_here[0]
+                    is_friendly = player.name in self._friendly_names
+                    team = "friendly" if is_friendly else "enemy"
+                    colors = TEAM_COLORS[team]
+                    # Bottom half shows player name snippet
+                    name_snip = player.name[:6].center(CELL_WIDTH)
+                    style = Style(
+                        color=colors["fg"],
+                        bgcolor=colors["bg"],
+                        dim=True,
+                    )
+                    result.append(name_snip, style=style)
+                elif cell_value == 0:
+                    result.append(" " * CELL_WIDTH)
+                else:
+                    terrain_name = _VALUE_TO_TERRAIN.get(cell_value, "plains")
+                    _, bot_sym, fg, bg = _TERRAIN_STYLE.get(terrain_name, _TERRAIN_STYLE["plains"])
+
+                    if position_str in self._flash_cells:
+                        style = Style(color="#000000", bgcolor="#00ffff", bold=True)
+                        result.append(_FLASH_BOT, style=style)
+                    elif position_str in self._highlight_cells:
+                        style = Style(color="#00ffff", bgcolor="#1a3a3a", bold=True)
+                        result.append(_HIGHLIGHT_BOT, style=style)
+                    else:
+                        style = Style(color=fg, bgcolor=bg)
+                        result.append(bot_sym, style=style)
 
             result.append("\u2551\n", style=border_style)
 
         # Bottom border
         result.append("     \u255a", style=border_style)
-        result.append("\u2550" * (CELL_WIDTH * self._grid_size + 1), style=border_style)
+        result.append("\u2550" * inner_width, style=border_style)
         result.append("\u255d\n", style=border_style)
 
-        # Legend — player tokens
+        # Legend — player tokens (compact, 2 columns)
+        alive_players = [p for p in self._players if not (hasattr(p, "is_alive") and not p.is_alive())]
         result.append("     ")
-        for p in self._players:
-            if hasattr(p, "is_alive") and not p.is_alive():
-                continue
+        for i, p in enumerate(alive_players):
             job_name = p.job.name if hasattr(p.job, "name") else str(p.job)
             token = get_player_token(p.name, job_name)
             is_friendly = p.name in self._friendly_names
             team = "friendly" if is_friendly else "enemy"
             colors = TEAM_COLORS[team]
-            result.append(f"[{token}]", style=Style(color=colors["fg"], bgcolor=colors["bg"], bold=True))
-            result.append(f" {p.name}", style=Style(color="#8b949e"))
-            result.append("  ")
+            result.append(
+                f"[{token}]",
+                style=Style(color=colors["fg"], bgcolor=colors["bg"], bold=True),
+            )
+            result.append(f"{p.name} ", style=Style(color="#8b949e"))
         result.append("\n")
 
         return result

--- a/emberblast/tui/widgets/map_grid.py
+++ b/emberblast/tui/widgets/map_grid.py
@@ -1,0 +1,143 @@
+"""Map grid widget for the Textual TUI."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Set
+
+from rich.style import Style
+from rich.text import Text
+from textual.widget import Widget
+
+from emberblast.tui.styles import (
+    TEAM_COLORS,
+    TERRAIN_COLORS,
+    get_player_token,
+    get_terrain_cell,
+)
+from emberblast.utils import convert_number_to_letter
+
+# Map matrix integer values to terrain type names.
+# 0 is always void; 1 defaults to plains.
+_VALUE_TO_TERRAIN: Dict[int, str] = {
+    1: "plains",
+    2: "wall",
+    3: "water",
+    4: "mountain",
+    5: "forest",
+}
+
+
+class MapWidget(Widget):
+    """Renders a grid map with terrain, players, and highlights."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._matrix: List[List[int]] = []
+        self._size: int = 0
+        self._players: list = []
+        self._active_player_name: str = ""
+        self._friendly_names: Set[str] = set()
+        self._flash_cells: Set[str] = set()
+        self._highlight_cells: Set[str] = set()
+
+    def update_map(
+        self,
+        matrix: List[List[int]],
+        size: int,
+        players: list,
+        active_player_name: str,
+        friendly_names: Set[str],
+        flash_cells: Optional[Set[str]] = None,
+        highlight_cells: Optional[Set[str]] = None,
+    ) -> None:
+        """Update the map data and trigger a refresh."""
+        self._matrix = matrix
+        self._size = size
+        self._players = players
+        self._active_player_name = active_player_name
+        self._friendly_names = friendly_names
+        self._flash_cells = flash_cells or set()
+        self._highlight_cells = highlight_cells or set()
+        self.refresh()
+
+    def _build_grid_text(self) -> Text:
+        """Build a Rich Text object representing the full grid."""
+        if not self._matrix or self._size == 0:
+            return Text("No map data")
+
+        # Index players by (row, col) for fast lookup
+        player_positions: Dict[tuple, list] = {}
+        for p in self._players:
+            if hasattr(p, "is_alive") and not p.is_alive():
+                continue
+            pos = p.position
+            if isinstance(pos, list) and len(pos) == 2:
+                key = (pos[0], pos[1])
+            elif isinstance(pos, str) and len(pos) >= 2:
+                row_letter = pos[0].upper()
+                col = int(pos[1:])
+                key = (ord(row_letter) - ord("A"), col)
+            else:
+                continue
+            player_positions.setdefault(key, []).append(p)
+
+        result = Text()
+
+        # Column headers
+        result.append("   ")
+        for col in range(self._size):
+            header = f"{col:>2} "
+            result.append(header, style=Style(bold=True, dim=True))
+        result.append("\n")
+
+        # Rows
+        for row in range(self._size):
+            row_label = convert_number_to_letter(row)
+            result.append(f"{row_label}  ", style=Style(bold=True, dim=True))
+
+            for col in range(self._size):
+                cell_value = self._matrix[row][col]
+                position_key = (row, col)
+                position_str = f"{row_label}{col}"
+
+                # Check for players at this position
+                players_here = player_positions.get(position_key, [])
+
+                if players_here:
+                    player = players_here[0]
+                    job_name = player.job.name if hasattr(player.job, "name") else str(player.job)
+                    token = get_player_token(player.name, job_name)
+                    is_friendly = player.name in self._friendly_names
+                    team = "friendly" if is_friendly else "enemy"
+                    colors = TEAM_COLORS[team]
+                    style = Style(
+                        color=colors["fg"],
+                        bgcolor=colors["bg"],
+                        bold=True,
+                        blink=player.name == self._active_player_name,
+                    )
+                    result.append(f"{token} ", style=style)
+                elif cell_value == 0:
+                    # Void cell
+                    result.append("   ")
+                else:
+                    terrain_name = _VALUE_TO_TERRAIN.get(cell_value, "plains")
+                    symbol = get_terrain_cell(terrain_name)
+                    color = TERRAIN_COLORS.get(terrain_name, TERRAIN_COLORS["plains"])
+
+                    style_kwargs: dict = {"color": color}
+                    if position_str in self._highlight_cells:
+                        style_kwargs["underline"] = True
+                    if position_str in self._flash_cells:
+                        style_kwargs["bold"] = True
+                        style_kwargs["reverse"] = True
+
+                    result.append(f"{symbol} ", style=Style(**style_kwargs))
+
+            result.append("\n")
+
+        return result
+
+    def render(self) -> Text:
+        """Render the widget content."""
+        return self._build_grid_text()

--- a/emberblast/tui/widgets/map_grid.py
+++ b/emberblast/tui/widgets/map_grid.py
@@ -23,17 +23,17 @@ _VALUE_TO_TERRAIN: Dict[int, str] = {
     5: "forest",
 }
 
-# Terrain rendering: (symbol, foreground, background)
+# Terrain rendering: (symbol, foreground, background) — 5-char wide cells
 _TERRAIN_STYLE: Dict[str, tuple] = {
-    "plains": (" ∙∙ ", "#484f58", "#1a1e24"),
-    "wall": (" ██ ", "#6e7681", "#2d333b"),
-    "water": (" ~~ ", "#58a6ff", "#0c2d4a"),
-    "mountain": (" /\\ ", "#f0883e", "#2a1a0a"),
-    "forest": (" ♣♣ ", "#3fb950", "#0a2a0f"),
+    "plains": (" \u00b7.\u00b7 ", "#484f58", "#1a1e24"),
+    "wall": (" \u2588\u2588\u2588 ", "#6e7681", "#2d333b"),
+    "water": (" \u2248\u2248\u2248 ", "#58a6ff", "#0c2d4a"),
+    "mountain": (" /\u25b2\\ ", "#f0883e", "#2a1a0a"),
+    "forest": (" \u2660\u2663\u2660 ", "#3fb950", "#0a2a0f"),
 }
 
 # Cell width must match symbol length
-CELL_WIDTH = 4
+CELL_WIDTH = 5
 
 
 class MapWidget(Widget):
@@ -44,6 +44,7 @@ class MapWidget(Widget):
         background: #0d1117;
         padding: 1;
         border: solid #f0883e;
+        height: 1fr;
     }
     """
 
@@ -101,19 +102,20 @@ class MapWidget(Widget):
         result = Text()
 
         # Column headers
-        result.append("     ")
+        result.append("      ")
         for col in range(self._grid_size):
-            result.append(f" {col:^3}", style=Style(bold=True, color="#6e7681"))
+            result.append(f" {col:^4}", style=Style(bold=True, color="#6e7681"))
         result.append("\n")
 
-        # Top border
-        result.append("   ┌─")
-        result.append("────" * self._grid_size)
-        result.append("┐\n", style=Style(color="#f0883e"))
+        # Top border — double-line box drawing
+        border_style = Style(color="#f0883e")
+        result.append("    \u2554\u2550", style=border_style)
+        result.append("\u2550\u2550\u2550\u2550\u2550" * self._grid_size, style=border_style)
+        result.append("\u2557\n", style=border_style)
 
         for row in range(self._grid_size):
             row_label = convert_number_to_letter(row)
-            result.append(f" {row_label} │ ", style=Style(bold=True, color="#6e7681"))
+            result.append(f"  {row_label} \u2551 ", style=Style(bold=True, color="#6e7681"))
 
             for col in range(self._grid_size):
                 cell_value = self._matrix[row][col]
@@ -135,9 +137,9 @@ class MapWidget(Widget):
                         bold=True,
                         blink=is_active,
                     )
-                    result.append(f" {token} ", style=style)
+                    result.append(f" [{token}]", style=style)
                 elif cell_value == 0:
-                    result.append("    ")
+                    result.append("     ")
                 else:
                     terrain_name = _VALUE_TO_TERRAIN.get(cell_value, "plains")
                     symbol, fg, bg = _TERRAIN_STYLE.get(terrain_name, _TERRAIN_STYLE["plains"])
@@ -151,15 +153,15 @@ class MapWidget(Widget):
 
                     result.append(symbol, style=style)
 
-            result.append("│\n", style=Style(color="#f0883e"))
+            result.append("\u2551\n", style=border_style)
 
         # Bottom border
-        result.append("   └─")
-        result.append("────" * self._grid_size)
-        result.append("┘\n", style=Style(color="#f0883e"))
+        result.append("    \u255a\u2550", style=border_style)
+        result.append("\u2550\u2550\u2550\u2550\u2550" * self._grid_size, style=border_style)
+        result.append("\u255d\n", style=border_style)
 
         # Legend
-        result.append("\n ")
+        result.append("\n  ")
         for p in self._players:
             if hasattr(p, "is_alive") and not p.is_alive():
                 continue
@@ -168,8 +170,8 @@ class MapWidget(Widget):
             is_friendly = p.name in self._friendly_names
             team = "friendly" if is_friendly else "enemy"
             colors = TEAM_COLORS[team]
-            result.append(f" {token}", style=Style(color=colors["fg"], bgcolor=colors["bg"], bold=True))
-            result.append(f"={p.name}", style=Style(color="#8b949e"))
+            result.append(f"[{token}]", style=Style(color=colors["fg"], bgcolor=colors["bg"], bold=True))
+            result.append(f" {p.name}", style=Style(color="#8b949e"))
             result.append("  ")
 
         return result

--- a/emberblast/tui/widgets/map_grid.py
+++ b/emberblast/tui/widgets/map_grid.py
@@ -23,22 +23,23 @@ _VALUE_TO_TERRAIN: Dict[int, str] = {
     5: "forest",
 }
 
-# Terrain rendering: (top_symbol, bottom_symbol, foreground, background) — 8-char wide cells
+# Terrain rendering: (top_symbol, bottom_symbol, foreground, background) — 10-char wide cells
+# All symbols MUST be exactly CELL_WIDTH ASCII/single-width chars for alignment.
 _TERRAIN_STYLE: Dict[str, tuple] = {
-    "plains": ("   \u00b7\u00b7   ", "        ", "#484f58", "#131820"),
-    "wall": ("  \u2588\u2588\u2588\u2588  ", "  \u2588\u2588\u2588\u2588  ", "#6e7681", "#2d333b"),
-    "water": ("  \u2248\u2248\u2248\u2248  ", "  \u223c\u223c\u223c\u223c  ", "#58a6ff", "#0a2240"),
-    "mountain": ("  /\u25b2\\   ", "  \\__/  ", "#f0883e", "#2a1a0a"),
-    "forest": ("  \u2663\u2663\u2663\u2663  ", "  \u2502\u2502\u2502\u2502  ", "#3fb950", "#0a2a0f"),
+    "plains": ("    ..    ", "          ", "#484f58", "#131820"),
+    "wall": ("  ######  ", "  ######  ", "#6e7681", "#2d333b"),
+    "water": ("   ~~~~   ", "   ~~~~   ", "#58a6ff", "#0a2240"),
+    "mountain": ("   /^^\\   ", "   /  \\   ", "#f0883e", "#2a1a0a"),
+    "forest": ("   YYYY   ", "   ||||   ", "#3fb950", "#0a2a0f"),
 }
 
 # Highlight terrain symbols
-_HIGHLIGHT_TOP = "  \u25aa\u25aa\u25aa\u25aa  "
-_HIGHLIGHT_BOT = "  \u25aa\u25aa\u25aa\u25aa  "
-_FLASH_TOP = "  \u25c6\u25c6\u25c6\u25c6  "
-_FLASH_BOT = "  \u25c6\u25c6\u25c6\u25c6  "
+_HIGHLIGHT_TOP = "   ****   "
+_HIGHLIGHT_BOT = "   ****   "
+_FLASH_TOP = "   <><<>  "
+_FLASH_BOT = "   <><<>  "
 
-CELL_WIDTH = 8
+CELL_WIDTH = 10
 
 
 class MapWidget(Widget):
@@ -108,15 +109,11 @@ class MapWidget(Widget):
         header_style = Style(bold=True, color="#6e7681")
         inner_width = CELL_WIDTH * self._grid_size + 1
 
-        # Column headers
+        # Column headers — aligned with grid interior
         result.append("\n")
-        result.append("       ")
+        result.append("      ")
         for col in range(self._grid_size):
-            label = str(col)
-            pad = CELL_WIDTH - len(label)
-            left_pad = pad // 2
-            right_pad = pad - left_pad
-            result.append(" " * left_pad + label + " " * right_pad, style=header_style)
+            result.append(str(col).center(CELL_WIDTH), style=header_style)
         result.append("\n")
 
         # Top border — heavy double-line
@@ -150,7 +147,7 @@ class MapWidget(Widget):
                         bold=True,
                         blink=is_active,
                     )
-                    result.append(f"  [{token}]  ", style=style)
+                    result.append(f"   [{token}]   ", style=style)
                 elif cell_value == 0:
                     result.append(" " * CELL_WIDTH)
                 else:

--- a/emberblast/tui/widgets/map_grid.py
+++ b/emberblast/tui/widgets/map_grid.py
@@ -162,17 +162,6 @@ class MapWidget(Widget):
 
             result.append("\u2551\n", style=border_style)
 
-            # Spacing row between grid rows (half-height visual separator)
-            if row < self._grid_size - 1:
-                result.append("     \u2551", style=border_style)
-                for col in range(self._grid_size):
-                    cell_value = self._matrix[row][col]
-                    terrain_name = _VALUE_TO_TERRAIN.get(cell_value, "plains")
-                    _, _, bg = _TERRAIN_STYLE.get(terrain_name, _TERRAIN_STYLE["plains"])
-                    # Subtle row separator
-                    result.append("\u2500" * CELL_WIDTH, style=Style(color="#21262d"))
-                result.append("\u2551\n", style=border_style)
-
         # Bottom border
         result.append("     \u255a", style=border_style)
         result.append("\u2550" * (CELL_WIDTH * self._grid_size + 1), style=border_style)

--- a/emberblast/tui/widgets/map_grid.py
+++ b/emberblast/tui/widgets/map_grid.py
@@ -132,14 +132,16 @@ class MapWidget(Widget):
                     symbol = get_terrain_cell(terrain_name)
                     color = TERRAIN_COLORS.get(terrain_name, TERRAIN_COLORS["plains"])
 
-                    style_kwargs: dict = {"color": color}
                     if position_str in self._highlight_cells:
-                        style_kwargs["underline"] = True
-                    if position_str in self._flash_cells:
-                        style_kwargs["bold"] = True
-                        style_kwargs["reverse"] = True
-
-                    result.append(f"{symbol} ", style=Style(**style_kwargs))
+                        # Movement possibility: bright cyan with reverse for high visibility
+                        style = Style(color="#00ffff", bgcolor="#1a4040", bold=True)
+                        result.append(f"{symbol} ", style=style)
+                    elif position_str in self._flash_cells:
+                        # Flash effect: inverted colors for damage/effects
+                        style = Style(color=color, bold=True, reverse=True)
+                        result.append(f"{symbol} ", style=style)
+                    else:
+                        result.append(f"{symbol} ", style=Style(color=color))
 
             result.append("\n")
 

--- a/emberblast/tui/widgets/map_grid.py
+++ b/emberblast/tui/widgets/map_grid.py
@@ -26,6 +26,9 @@ _VALUE_TO_TERRAIN: Dict[int, str] = {
     5: "forest",
 }
 
+# Cell width: 4 chars per cell (symbol + padding) for better readability
+CELL_WIDTH = 4
+
 
 class MapWidget(Widget):
     """Renders a grid map with terrain, players, and highlights."""
@@ -34,6 +37,7 @@ class MapWidget(Widget):
     MapWidget {
         background: #0d1117;
         padding: 1;
+        border: solid #30363d;
     }
     """
 
@@ -90,17 +94,22 @@ class MapWidget(Widget):
 
         result = Text()
 
-        # Column headers
-        result.append("   ")
+        # Column headers — wider spacing to match cells
+        result.append("    ")  # row label padding
         for col in range(self._grid_size):
-            header = f"{col:>2} "
+            header = f"{col:^{CELL_WIDTH}}"
             result.append(header, style=Style(bold=True, dim=True))
         result.append("\n")
+
+        # Top border
+        result.append("   ┌")
+        result.append("─" * (self._grid_size * CELL_WIDTH))
+        result.append("┐\n", style=Style(color="#30363d"))
 
         # Rows
         for row in range(self._grid_size):
             row_label = convert_number_to_letter(row)
-            result.append(f"{row_label}  ", style=Style(bold=True, dim=True))
+            result.append(f" {row_label} │", style=Style(bold=True, dim=True))
 
             for col in range(self._grid_size):
                 cell_value = self._matrix[row][col]
@@ -117,33 +126,55 @@ class MapWidget(Widget):
                     is_friendly = player.name in self._friendly_names
                     team = "friendly" if is_friendly else "enemy"
                     colors = TEAM_COLORS[team]
+                    is_active = player.name == self._active_player_name
                     style = Style(
                         color=colors["fg"],
                         bgcolor=colors["bg"],
                         bold=True,
-                        blink=player.name == self._active_player_name,
+                        blink=is_active,
                     )
-                    result.append(f"{token} ", style=style)
+                    # Center token in cell
+                    cell = f" {token} "
+                    result.append(cell, style=style)
                 elif cell_value == 0:
                     # Void cell
-                    result.append("   ")
+                    result.append(" " * CELL_WIDTH)
                 else:
                     terrain_name = _VALUE_TO_TERRAIN.get(cell_value, "plains")
                     symbol = get_terrain_cell(terrain_name)
                     color = TERRAIN_COLORS.get(terrain_name, TERRAIN_COLORS["plains"])
 
                     if position_str in self._highlight_cells:
-                        # Movement possibility: bright cyan with reverse for high visibility
+                        # Movement possibility: bright cyan background
                         style = Style(color="#00ffff", bgcolor="#1a4040", bold=True)
-                        result.append(f"{symbol} ", style=style)
                     elif position_str in self._flash_cells:
-                        # Flash effect: inverted colors for damage/effects
-                        style = Style(color=color, bold=True, reverse=True)
-                        result.append(f"{symbol} ", style=style)
+                        # Flash effect: inverted colors for the selected cell
+                        style = Style(color="#000000", bgcolor="#00ffff", bold=True)
                     else:
-                        result.append(f"{symbol} ", style=Style(color=color))
+                        style = Style(color=color)
 
-            result.append("\n")
+                    cell = f" {symbol} "
+                    result.append(cell, style=style)
+
+            result.append("│\n", style=Style(color="#30363d"))
+
+        # Bottom border
+        result.append("   └")
+        result.append("─" * (self._grid_size * CELL_WIDTH))
+        result.append("┘\n", style=Style(color="#30363d"))
+
+        # Legend
+        result.append("\n")
+        for p in self._players:
+            if hasattr(p, "is_alive") and not p.is_alive():
+                continue
+            job_name = p.job.name if hasattr(p.job, "name") else str(p.job)
+            token = get_player_token(p.name, job_name)
+            is_friendly = p.name in self._friendly_names
+            team = "friendly" if is_friendly else "enemy"
+            colors = TEAM_COLORS[team]
+            result.append(f" {token}", style=Style(color=colors["fg"], bold=True))
+            result.append(f"={p.name} ", style=Style(dim=True))
 
         return result
 

--- a/emberblast/tui/widgets/player_hud.py
+++ b/emberblast/tui/widgets/player_hud.py
@@ -40,6 +40,13 @@ def _build_bar(current: int, maximum: int, label: str) -> Text:
 class PlayerHUDWidget(Widget):
     """Displays player name, job, race, HP bar, MP bar, and stats."""
 
+    DEFAULT_CSS = """
+    PlayerHUDWidget {
+        background: #161b22;
+        padding: 1;
+    }
+    """
+
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
         self._player: Optional[object] = None

--- a/emberblast/tui/widgets/player_hud.py
+++ b/emberblast/tui/widgets/player_hud.py
@@ -1,0 +1,87 @@
+"""Player HUD widget for the Textual TUI."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from rich.style import Style
+from rich.text import Text
+from textual.widget import Widget
+
+BAR_WIDTH = 20
+FILLED = "\u2588"  # █
+EMPTY = "\u2591"  # ░
+
+
+def _bar_color(ratio: float) -> str:
+    """Return a hex color based on the health/mana ratio."""
+    if ratio > 0.50:
+        return "#3fb950"  # green
+    if ratio > 0.25:
+        return "#e3b341"  # yellow
+    return "#f85149"  # red
+
+
+def _build_bar(current: int, maximum: int, label: str) -> Text:
+    """Build a colored bar with label and numeric values."""
+    ratio = current / maximum if maximum > 0 else 0
+    filled_count = round(ratio * BAR_WIDTH)
+    empty_count = BAR_WIDTH - filled_count
+    color = _bar_color(ratio)
+
+    bar = Text()
+    bar.append(f"{label}: ", style=Style(bold=True))
+    bar.append(FILLED * filled_count, style=Style(color=color))
+    bar.append(EMPTY * empty_count, style=Style(color="#30363d"))
+    bar.append(f" {current}/{maximum}", style=Style(dim=True))
+    return bar
+
+
+class PlayerHUDWidget(Widget):
+    """Displays player name, job, race, HP bar, MP bar, and stats."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._player: Optional[object] = None
+
+    def update_player(self, player: object) -> None:
+        """Update the displayed player and refresh."""
+        self._player = player
+        self.refresh()
+
+    def _build_hud_text(self) -> Text:
+        """Build a Rich Text object for the HUD display."""
+        if self._player is None:
+            return Text("No player data")
+
+        p = self._player
+        result = Text()
+
+        # Name / Job / Race / Level
+        job_name = p.job.name if hasattr(p.job, "name") else str(p.job)
+        race_name = p.race.name if hasattr(p.race, "name") else str(p.race)
+        result.append(f"{p.name}", style=Style(bold=True, color="#58a6ff"))
+        result.append(f"  Lv.{p.level} {job_name} ({race_name})\n", style=Style(dim=True))
+
+        # HP bar
+        hp_bar = _build_bar(p.life, p.health_points, "HP")
+        result.append_text(hp_bar)
+        result.append("\n")
+
+        # MP bar
+        mp_bar = _build_bar(p.mana, p.magic_points, "MP")
+        result.append_text(mp_bar)
+        result.append("\n")
+
+        # Stats line
+        stats = (
+            f"STR:{p.strength}  INT:{p.intelligence}  ACC:{p.accuracy}  "
+            f"ARM:{p.armour}  RES:{p.magic_resist}  SPD:{p.move_speed}  WILL:{p.will}"
+        )
+        result.append(stats, style=Style(dim=True))
+
+        return result
+
+    def render(self) -> Text:
+        """Render the widget content."""
+        return self._build_hud_text()

--- a/emberblast/tui/widgets/player_hud.py
+++ b/emberblast/tui/widgets/player_hud.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import List, Optional
 
 from rich.style import Style
 from rich.text import Text
@@ -22,11 +22,11 @@ def _bar_color(ratio: float) -> str:
     return "#f85149"  # red
 
 
-def _build_bar(current: int, maximum: int, label: str) -> Text:
+def _build_bar(current: int, maximum: int, label: str, bar_width: int = BAR_WIDTH) -> Text:
     """Build a colored bar with label and numeric values."""
     ratio = current / maximum if maximum > 0 else 0
-    filled_count = round(ratio * BAR_WIDTH)
-    empty_count = BAR_WIDTH - filled_count
+    filled_count = round(ratio * bar_width)
+    empty_count = bar_width - filled_count
     color = _bar_color(ratio)
 
     bar = Text()
@@ -38,37 +38,48 @@ def _build_bar(current: int, maximum: int, label: str) -> Text:
 
 
 class PlayerHUDWidget(Widget):
-    """Displays player name, job, race, HP bar, MP bar, and stats."""
+    """Displays controlled player stats and a compact enemy list."""
 
     DEFAULT_CSS = """
     PlayerHUDWidget {
         background: #161b22;
         padding: 1;
+        border: solid #30363d;
     }
     """
 
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
         self._player: Optional[object] = None
+        self._enemies: List[object] = []
 
     def update_player(self, player: object) -> None:
         """Update the displayed player and refresh."""
         self._player = player
         self.refresh()
 
+    def update_enemies(self, enemies: List[object]) -> None:
+        """Update the enemy list and refresh."""
+        self._enemies = list(enemies)
+        self.refresh()
+
     def _build_hud_text(self) -> Text:
         """Build a Rich Text object for the HUD display."""
-        if self._player is None:
-            return Text("No player data")
-
-        p = self._player
         result = Text()
 
-        # Name / Job / Race / Level
+        if self._player is None:
+            result.append("No player data", style=Style(dim=True))
+            return result
+
+        p = self._player
+
+        # ── Your character ──
         job_name = p.job.name if hasattr(p.job, "name") else str(p.job)
         race_name = p.race.name if hasattr(p.race, "name") else str(p.race)
-        result.append(f"{p.name}", style=Style(bold=True, color="#58a6ff"))
-        result.append(f"  Lv.{p.level} {job_name} ({race_name})\n", style=Style(dim=True))
+        result.append(f"⚔ {p.name}", style=Style(bold=True, color="#58a6ff"))
+        result.append(f"  {race_name}\n", style=Style(color="#8b949e"))
+        result.append(f"  {job_name}", style=Style(color="#8b949e"))
+        result.append(f"  Lv.{p.level}\n", style=Style(color="#f0883e", bold=True))
 
         # HP bar
         hp_bar = _build_bar(p.life, p.health_points, "HP")
@@ -80,12 +91,32 @@ class PlayerHUDWidget(Widget):
         result.append_text(mp_bar)
         result.append("\n")
 
-        # Stats line
-        stats = (
-            f"STR:{p.strength}  INT:{p.intelligence}  ACC:{p.accuracy}  "
-            f"ARM:{p.armour}  RES:{p.magic_resist}  SPD:{p.move_speed}  WILL:{p.will}"
+        # Stats
+        result.append(
+            f"STR:{p.strength} INT:{p.intelligence} ACC:{p.accuracy} "
+            f"ARM:{p.armour} RES:{p.magic_resist} SPD:{p.move_speed} WILL:{p.will}\n",
+            style=Style(dim=True),
         )
-        result.append(stats, style=Style(dim=True))
+
+        # ── Enemy list ──
+        alive_enemies = [e for e in self._enemies if hasattr(e, "is_alive") and e.is_alive()]
+        if alive_enemies:
+            result.append("─" * 30 + "\n", style=Style(color="#30363d"))
+            result.append("ENEMIES\n", style=Style(bold=True, color="#f85149"))
+            for e in alive_enemies:
+                ej = e.job.name if hasattr(e.job, "name") else str(e.job)
+                hp_ratio = e.life / e.health_points if e.health_points > 0 else 0
+                hp_color = _bar_color(hp_ratio)
+                mini_bar_w = 10
+                filled = round(hp_ratio * mini_bar_w)
+                empty = mini_bar_w - filled
+
+                result.append(f"  {e.name}", style=Style(color="#f85149"))
+                result.append(f" {ej}", style=Style(dim=True))
+                result.append(f" Lv.{e.level} ", style=Style(dim=True))
+                result.append(FILLED * filled, style=Style(color=hp_color))
+                result.append(EMPTY * empty, style=Style(color="#30363d"))
+                result.append(f" {e.life}/{e.health_points}\n", style=Style(dim=True))
 
         return result
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "cloudpickle>=1.6.0",
     "rich>=13.0.0",
     "openai>=1.0.0",
+    "textual>=0.50.0",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -88,6 +88,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
     { name = "sqlparse" },
+    { name = "textual" },
 ]
 
 [package.dev-dependencies]
@@ -106,6 +107,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=5.4.1" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "sqlparse", specifier = ">=0.4.1" },
+    { name = "textual", specifier = ">=0.50.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -292,6 +294,18 @@ wheels = [
 ]
 
 [[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -301,6 +315,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205, upload-time = "2025-08-11T07:25:47.597Z" },
 ]
 
 [[package]]
@@ -494,6 +525,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d9/5a/32b50c077c86bfccc7bed4881c5a2b823518f5450a30e639db5d3711952e/pfzy-0.3.4.tar.gz", hash = "sha256:717ea765dd10b63618e7298b2d98efd819e0b30cd5905c9707223dceeb94b3f1", size = 8396, upload-time = "2022-01-28T02:26:17.946Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8c/d7/8ff98376b1acc4503253b685ea09981697385ce344d4e3935c2af49e044d/pfzy-0.3.4-py3-none-any.whl", hash = "sha256:5f50d5b2b3207fa72e7ec0ef08372ef652685470974a107d0d4999fc5a903a96", size = 8537, upload-time = "2022-01-28T02:26:16.047Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
 ]
 
 [[package]]
@@ -798,6 +838,23 @@ wheels = [
 ]
 
 [[package]]
+name = "textual"
+version = "8.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/41/fd22435b96a50f24472af31f15e9874ce0ffef0edabb74fcf3d598ab8e53/textual-8.2.0.tar.gz", hash = "sha256:a06201a732b2d2683d2ea11c2538eeb7315c4c7138ed8c8bdb48150b805eaf1e", size = 1847670, upload-time = "2026-03-27T09:28:29.976Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/41/ed1f3e47b71b9e0bae23445189274048332a423798627d47e30314c739a0/textual-8.2.0-py3-none-any.whl", hash = "sha256:0478fed6e945bcadd6f3841e10d05213d318cdb5c4345c04ae78f7ec32e7b63d", size = 723752, upload-time = "2026-03-27T09:28:32.705Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -882,6 +939,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Async refactor**: Convert entire game loop, orchestrator, questioner, factory, and bot decisioning to `async/await`. Replaces `time.sleep()` with `asyncio.sleep()`, wraps blocking InquirerPy/OpenAI calls with `asyncio.to_thread()`
- **Textual TUI**: Full terminal UI replacing Rich CLI renderer and InquirerPy input — title screen, setup screens, battle screen with map grid, player HUD, combat log, and action bar widgets
- **TextualRenderer + TextualQuestioner**: New implementations of `IRenderer` and `IQuestioningSystem` using Textual widgets and `asyncio.Event` for game loop ↔ UI communication
- **Classic mode fallback**: `--classic` flag preserves original InquirerPy + Rich CLI behavior
- **219 tests passing**, 17 skipped

## How to Test

```bash
# Install dependencies
uv sync

# Run Textual TUI mode (default)
uv run emberblast

# Run classic CLI mode (original behavior)
uv run emberblast --classic

# Run tests
uv run python -m pytest emberblast/test/ -v
```

### TUI Mode
- Title screen: arrow keys + Enter to select New Game
- Setup: select game type, map, number of players/bots, create characters
- Battle: use keyboard shortcuts — [M]ove, [A]ttack, [S]kill, [D]efend, [I]tem, [C]heck, [P]ass
- Navigate lists with arrow keys or j/k, confirm with Enter, cancel with Escape

### Classic Mode
- Same as before — InquirerPy prompts in the terminal

## Test Plan
- [ ] `uv run python -m pytest emberblast/test/ -v` — all 219 tests pass
- [ ] `uv run emberblast` — Textual TUI launches, title screen displays
- [ ] `uv run emberblast --classic` — classic CLI mode works as before
- [ ] Start a new game in TUI mode — setup flow completes, battle screen renders
- [ ] Bot turns auto-play with ~0.5s pacing